### PR TITLE
Add CSV column lookup and cost resolver for flexible graph import

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ Instruction has been made for Linux mainly. For Windows or OSX the way may vary.
     * map_vertices.csv - Information about vertices and its geometries
     * map_shortcuts.csv - Information about shortcuts which are obtained by contraction process
 
+    **CSV column lookup.** Horizon reads columns by header name, not by position. This means column order in CSV files does not matter and extra columns are safely ignored. Required columns per file:
+
+    | File | Required columns |
+    |------|-----------------|
+    | edges (map.csv) | `from_vertex_id`, `to_vertex_id`, `geom`, `edge_id` + cost (see below) |
+    | vertices (map_vertices.csv) | `vertex_id`, `order_pos`, `importance`, `geom` |
+    | shortcuts (map_shortcuts.csv) | `from_vertex_id`, `to_vertex_id`, `weight`, `via_vertex_id` |
+
+    **Edge cost resolution.** Horizon determines edge cost using a fallback chain:
+    1. `weight` column exists - use it directly (backward compatibility with osm2ch output)
+    2. `length_meters` + `free_speed` columns exist - compute travel time: `length_meters / (free_speed / 3.6)` (seconds)
+    3. Only `length_meters` exists - use distance as cost
+    4. None of the above - error
+
+    The chosen strategy is printed at startup.
+
 5. Start **horizon** server. Provide bind address, port, filename for edges file, σ and β parameters, initial longitude/latitude (in example Moscow coordinates are provided) and zoom for web page of your needs. 
     ```shell
     horizon -h 0.0.0.0 -p 32800 -f map.csv -sigma 50.0 -beta 30.0 -maplon 37.60011784074581 -maplat 55.74694688386492 -mapzoom 17.0

--- a/cost_resolver.go
+++ b/cost_resolver.go
@@ -1,0 +1,105 @@
+package horizon
+
+import (
+	"fmt"
+)
+
+// CostStrategy describes how edge cost is determined from CSV columns.
+type CostStrategy int
+
+const (
+	// CostStrategyWeight uses the "weight" column directly (backward compatibility).
+	CostStrategyWeight CostStrategy = iota
+	// CostStrategyTime computes cost as length_meters / (free_speed / 3.6), i.e. travel time in seconds.
+	CostStrategyTime
+	// CostStrategyDistance uses "length_meters" as cost (no speed data available).
+	CostStrategyDistance
+)
+
+func (s CostStrategy) String() string {
+	switch s {
+	case CostStrategyWeight:
+		return "weight (backward-compat: raw weight column)"
+	case CostStrategyTime:
+		return "time (length_meters / free_speed)"
+	case CostStrategyDistance:
+		return "distance (length_meters, no speed data)"
+	default:
+		return "unknown"
+	}
+}
+
+// CostResolver determines edge cost from CSV records using a fallback chain:
+//
+//  1. "weight" column exists => use it directly (backward compat, logged)
+//  2. "length_meters" + "free_speed" exist => cost = length / (speed / 3.6) (travel time in seconds)
+//  3. only "length_meters" exists => cost = length_meters (distance-based)
+//  4. nothing useful => error
+//
+// @todo: maybe in future I could implement more complex strategies (e.g. parse geom and eval its length and so on)
+type CostResolver struct {
+	lookup   *CSVLookup
+	strategy CostStrategy
+}
+
+// NewCostResolver inspects CSV headers and selects the best cost strategy.
+// It logs which strategy was chosen.
+func NewCostResolver(lookup *CSVLookup) (*CostResolver, error) {
+	r := &CostResolver{lookup: lookup}
+
+	hasWeight := lookup.Has("weight")
+	hasLength := lookup.Has("length_meters")
+	hasSpeed := lookup.Has("free_speed")
+
+	switch {
+	case hasWeight:
+		r.strategy = CostStrategyWeight
+		if hasLength && hasSpeed {
+			fmt.Println("[cost-resolver] using 'weight' column (length_meters + free_speed also available but weight takes priority for backward compatibility)")
+		} else {
+			fmt.Println("[cost-resolver] using 'weight' column")
+		}
+	case hasLength && hasSpeed:
+		r.strategy = CostStrategyTime
+		fmt.Println("[cost-resolver] using time-based cost: length_meters / (free_speed / 3.6)")
+	case hasLength:
+		r.strategy = CostStrategyDistance
+		fmt.Println("[cost-resolver] using distance-based cost: length_meters (no free_speed column found)")
+	default:
+		return nil, fmt.Errorf("can't determine edge cost: need 'weight' or 'length_meters' column in CSV header")
+	}
+
+	return r, nil
+}
+
+// Strategy returns the selected cost strategy.
+func (r *CostResolver) Strategy() CostStrategy {
+	return r.strategy
+}
+
+// Resolve computes the cost for a single CSV record.
+func (r *CostResolver) Resolve(record []string) (float64, error) {
+	switch r.strategy {
+	case CostStrategyWeight:
+		return r.lookup.Float64(record, "weight")
+	case CostStrategyTime:
+		length, err := r.lookup.Float64(record, "length_meters")
+		if err != nil {
+			return 0, err
+		}
+		speed, err := r.lookup.Float64(record, "free_speed")
+		if err != nil {
+			return 0, err
+		}
+		if speed <= 0 {
+			return 0, fmt.Errorf("free_speed must be positive, got %f", speed)
+		}
+		// speed is km/h => m/s = speed / 3.6
+		// cost = length_meters / (speed_kmh / 3.6) = travel time in seconds
+		return length / (speed / 3.6), nil
+	case CostStrategyDistance:
+		return r.lookup.Float64(record, "length_meters")
+	default:
+		return 0, fmt.Errorf("unknown cost strategy: %d", r.strategy)
+	}
+}

--- a/cost_resolver_test.go
+++ b/cost_resolver_test.go
@@ -1,0 +1,101 @@
+package horizon
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCostResolverWeight(t *testing.T) {
+	lookup := NewCSVLookup([]string{"from_vertex_id", "to_vertex_id", "weight", "geom", "edge_id"})
+	r, err := NewCostResolver(lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Strategy() != CostStrategyWeight {
+		t.Fatalf("expected CostStrategyWeight, got %v", r.Strategy())
+	}
+
+	record := []string{"1", "2", "150.5", "LINESTRING(0 0,1 1)", "10"}
+	cost, err := r.Resolve(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost != 150.5 {
+		t.Fatalf("expected 150.5, got %f", cost)
+	}
+}
+
+func TestCostResolverTime(t *testing.T) {
+	lookup := NewCSVLookup([]string{"from_vertex_id", "to_vertex_id", "length_meters", "free_speed", "geom", "edge_id"})
+	r, err := NewCostResolver(lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Strategy() != CostStrategyTime {
+		t.Fatalf("expected CostStrategyTime, got %v", r.Strategy())
+	}
+
+	// 1000m at 36 km/h = 1000 / (36/3.6) = 1000 / 10 = 100 seconds
+	record := []string{"1", "2", "1000", "36", "LINESTRING(0 0,1 1)", "10"}
+	cost, err := r.Resolve(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(cost-100.0) > 0.001 {
+		t.Fatalf("expected 100.0 seconds, got %f", cost)
+	}
+}
+
+func TestCostResolverDistance(t *testing.T) {
+	lookup := NewCSVLookup([]string{"from_vertex_id", "to_vertex_id", "length_meters", "geom", "edge_id"})
+	r, err := NewCostResolver(lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Strategy() != CostStrategyDistance {
+		t.Fatalf("expected CostStrategyDistance, got %v", r.Strategy())
+	}
+
+	record := []string{"1", "2", "250.7", "LINESTRING(0 0,1 1)", "10"}
+	cost, err := r.Resolve(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost != 250.7 {
+		t.Fatalf("expected 250.7, got %f", cost)
+	}
+}
+
+func TestCostResolverWeightPriority(t *testing.T) {
+	// When weight AND length_meters+free_speed all present, weight wins
+	lookup := NewCSVLookup([]string{"from_vertex_id", "to_vertex_id", "weight", "length_meters", "free_speed", "geom", "edge_id"})
+	r, err := NewCostResolver(lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Strategy() != CostStrategyWeight {
+		t.Fatalf("expected CostStrategyWeight (priority), got %v", r.Strategy())
+	}
+}
+
+func TestCostResolverNoColumns(t *testing.T) {
+	lookup := NewCSVLookup([]string{"from_vertex_id", "to_vertex_id", "geom", "edge_id"})
+	_, err := NewCostResolver(lookup)
+	if err == nil {
+		t.Fatal("expected error when no cost columns are available")
+	}
+}
+
+func TestCostResolverZeroSpeed(t *testing.T) {
+	lookup := NewCSVLookup([]string{"length_meters", "free_speed"})
+	r, err := NewCostResolver(lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	record := []string{"1000", "0"}
+	_, err = r.Resolve(record)
+	if err == nil {
+		t.Fatal("expected error for zero speed")
+	}
+}

--- a/csv_lookup.go
+++ b/csv_lookup.go
@@ -1,0 +1,103 @@
+package horizon
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CSVLookup provides column name-based access to CSV records.
+// Instead of positional indexing (record[0], record[1], ...) it allows
+// accessing fields by header name: lookup.Int64(record, "source_vertex_id").
+type CSVLookup struct {
+	columns map[string]int
+}
+
+// NewCSVLookup creates a CSVLookup from a CSV header row.
+func NewCSVLookup(header []string) *CSVLookup {
+	columns := make(map[string]int, len(header))
+	for i, name := range header {
+		columns[name] = i
+	}
+	return &CSVLookup{columns: columns}
+}
+
+// Has returns true if the column exists in the header.
+func (l *CSVLookup) Has(name string) bool {
+	_, ok := l.columns[name]
+	return ok
+}
+
+// Index returns the column index for the given name.
+func (l *CSVLookup) Index(name string) (int, error) {
+	idx, ok := l.columns[name]
+	if !ok {
+		return -1, fmt.Errorf("column %q not found in CSV header", name)
+	}
+	return idx, nil
+}
+
+// String returns the string value of the named column.
+func (l *CSVLookup) String(record []string, name string) (string, error) {
+	idx, err := l.Index(name)
+	if err != nil {
+		return "", err
+	}
+	if idx >= len(record) {
+		return "", fmt.Errorf("column %q index %d out of range (record has %d fields)", name, idx, len(record))
+	}
+	return record[idx], nil
+}
+
+// Int64 parses the named column as int64.
+func (l *CSVLookup) Int64(record []string, name string) (int64, error) {
+	s, err := l.String(record, name)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("column %q: can't parse %q as int64: %w", name, s, err)
+	}
+	return v, nil
+}
+
+// Int parses the named column as int.
+func (l *CSVLookup) Int(record []string, name string) (int, error) {
+	s, err := l.String(record, name)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("column %q: can't parse %q as int: %w", name, s, err)
+	}
+	return v, nil
+}
+
+// Float64 parses the named column as float64.
+func (l *CSVLookup) Float64(record []string, name string) (float64, error) {
+	s, err := l.String(record, name)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("column %q: can't parse %q as float64: %w", name, s, err)
+	}
+	return v, nil
+}
+
+// MustHave validates that all required columns are present in the header.
+// Returns an error listing all missing columns.
+func (l *CSVLookup) MustHave(names ...string) error {
+	var missing []string
+	for _, name := range names {
+		if !l.Has(name) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("required CSV columns missing: %v", missing)
+	}
+	return nil
+}

--- a/csv_lookup_test.go
+++ b/csv_lookup_test.go
@@ -1,0 +1,106 @@
+package horizon
+
+import (
+	"testing"
+)
+
+func TestCSVLookupBasic(t *testing.T) {
+	header := []string{"id", "name", "weight", "count"}
+	lookup := NewCSVLookup(header)
+
+	record := []string{"42", "test_edge", "3.14", "7"}
+
+	// Has
+	if !lookup.Has("id") {
+		t.Fatal("expected 'id' column to exist")
+	}
+	if lookup.Has("missing") {
+		t.Fatal("expected 'missing' column to not exist")
+	}
+
+	// String
+	s, err := lookup.String(record, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "test_edge" {
+		t.Fatalf("expected 'test_edge', got %q", s)
+	}
+
+	// Int64
+	v, err := lookup.Int64(record, "id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 42 {
+		t.Fatalf("expected 42, got %d", v)
+	}
+
+	// Float64
+	f, err := lookup.Float64(record, "weight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f != 3.14 {
+		t.Fatalf("expected 3.14, got %f", f)
+	}
+
+	// Int
+	i, err := lookup.Int(record, "count")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i != 7 {
+		t.Fatalf("expected 7, got %d", i)
+	}
+}
+
+func TestCSVLookupMissingColumn(t *testing.T) {
+	header := []string{"id", "name"}
+	lookup := NewCSVLookup(header)
+	record := []string{"1", "foo"}
+
+	_, err := lookup.Int64(record, "weight")
+	if err == nil {
+		t.Fatal("expected error for missing column")
+	}
+}
+
+func TestCSVLookupMustHave(t *testing.T) {
+	header := []string{"id", "name", "geom"}
+	lookup := NewCSVLookup(header)
+
+	if err := lookup.MustHave("id", "name"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err := lookup.MustHave("id", "weight", "cost")
+	if err == nil {
+		t.Fatal("expected error for missing required columns")
+	}
+}
+
+func TestCSVLookupColumnOrder(t *testing.T) {
+	// Columns in different order than expected - lookup should still work
+	header := []string{"geom", "edge_id", "weight", "to_vertex_id", "from_vertex_id"}
+	lookup := NewCSVLookup(header)
+
+	record := []string{"LINESTRING(0 0,1 1)", "99", "150.5", "20", "10"}
+
+	from, err := lookup.Int64(record, "from_vertex_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	to, err := lookup.Int64(record, "to_vertex_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := lookup.Float64(record, "weight")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if from != 10 || to != 20 || w != 150.5 {
+		t.Fatalf("unexpected values: from=%d to=%d weight=%f", from, to, w)
+	}
+}

--- a/map_engine.go
+++ b/map_engine.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -149,11 +148,18 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 	readerEdges := csv.NewReader(fileEdges)
 	readerEdges.Comma = ';'
 
-	// Fill graph with edges informations
-	// Skip header of CSV-file
-	_, err = readerEdges.Read()
+	// Read header and build column lookup
+	edgesHeader, err := readerEdges.Read()
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Can't read header of edges file '%s'", edgesFname))
+	}
+	edgesLookup := NewCSVLookup(edgesHeader)
+	if err := edgesLookup.MustHave("from_vertex_id", "to_vertex_id", "geom", "edge_id"); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Invalid edges file '%s'", edgesFname))
+	}
+	costResolver, err := NewCostResolver(edgesLookup)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Invalid edges file '%s'", edgesFname))
 	}
 	// Read file line by line
 	for {
@@ -161,21 +167,21 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		if err == io.EOF {
 			break
 		}
-		sourceVertex, err := strconv.ParseInt(record[0], 10, 64)
+		sourceVertex, err := edgesLookup.Int64(record, "from_vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse source vertex in edges file. The vertex is '%s'", record[0]))
+			return errors.Wrap(err, "edges file")
 		}
-		targetVertex, err := strconv.ParseInt(record[1], 10, 64)
+		targetVertex, err := edgesLookup.Int64(record, "to_vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse target vertex in edges file. The vertex is '%s'", record[1]))
+			return errors.Wrap(err, "edges file")
 		}
-		weight, err := strconv.ParseFloat(record[2], 64)
+		weight, err := costResolver.Resolve(record)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse weight of an edge in edges file. The weight is '%s'", record[2]))
+			return errors.Wrap(err, "edges file")
 		}
-		edgeID, err := strconv.ParseInt(record[5], 10, 64)
+		edgeID, err := edgesLookup.Int64(record, "edge_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse edge identifier in edges file. The edge is '%s'", record[5]))
+			return errors.Wrap(err, "edges file")
 		}
 		err = engine.graph.CreateVertex(sourceVertex)
 		if err != nil {
@@ -190,7 +196,10 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 			return errors.Wrap(err, fmt.Sprintf("Can't add edge: from_vertex_id = '%d' | to_vertex_id = '%d'", sourceVertex, targetVertex))
 		}
 
-		coordinates := record[3]
+		coordinates, err := edgesLookup.String(record, "geom")
+		if err != nil {
+			return errors.Wrap(err, "edges file")
+		}
 		s2Polyline, err := spatial.WKTToS2PolylineFeature(coordinates)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Can't parse WKT geometry of the edge: from_vertex_id = '%d' | to_vertex_id = '%d' | geom = '%s'", sourceVertex, targetVertex, coordinates))
@@ -224,10 +233,14 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 	readerVertices := csv.NewReader(fileVertices)
 	readerVertices.Comma = ';'
 
-	// Skip header of CSV-file
-	_, err = readerVertices.Read()
+	// Read header and build column lookup
+	verticesHeader, err := readerVertices.Read()
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Can't read header of vertices file '%s'", edgesFname))
+		return errors.Wrap(err, fmt.Sprintf("Can't read header of vertices file '%s'", verticesFname))
+	}
+	verticesLookup := NewCSVLookup(verticesHeader)
+	if err := verticesLookup.MustHave("vertex_id", "order_pos", "importance", "geom"); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Invalid vertices file '%s'", verticesFname))
 	}
 	// Read file line by line
 	for {
@@ -235,17 +248,17 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		if err == io.EOF {
 			break
 		}
-		vertexExternal, err := strconv.ParseInt(record[0], 10, 64)
+		vertexExternal, err := verticesLookup.Int64(record, "vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse a vertex in vertices file. The vertex is '%s'", record[0]))
+			return errors.Wrap(err, "vertices file")
 		}
-		vertexOrderPos, err := strconv.ParseInt(record[1], 10, 64)
+		vertexOrderPos, err := verticesLookup.Int64(record, "order_pos")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse order position of vertex in vertices file. The order pos is '%s'", record[1]))
+			return errors.Wrap(err, "vertices file")
 		}
-		vertexImportance, err := strconv.Atoi(record[2])
+		vertexImportance, err := verticesLookup.Int(record, "importance")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse importance of vertex in vertices file. The importance is '%s'", record[2]))
+			return errors.Wrap(err, "vertices file")
 		}
 		vertexInternal, vertexFound := engine.graph.FindVertex(vertexExternal)
 		if !vertexFound {
@@ -254,7 +267,10 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		engine.graph.Vertices[vertexInternal].SetOrderPos(vertexOrderPos)
 		engine.graph.Vertices[vertexInternal].SetImportance(vertexImportance)
 
-		coordinates := record[3]
+		coordinates, err := verticesLookup.String(record, "geom")
+		if err != nil {
+			return errors.Wrap(err, "vertices file")
+		}
 		s2Point, err := spatial.WKTToS2PointFeature(coordinates)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Can't parse WKT geometry of the vertex '%d' | geom = '%s'", vertexExternal, coordinates))
@@ -274,10 +290,14 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 	defer fileShortcuts.Close()
 	readerShortcuts := csv.NewReader(fileShortcuts)
 	readerShortcuts.Comma = ';'
-	// Skip header of CSV-file
-	_, err = readerShortcuts.Read()
+	// Read header and build column lookup
+	shortcutsHeader, err := readerShortcuts.Read()
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Can't read header of shortcuts file '%s'", edgesFname))
+		return errors.Wrap(err, fmt.Sprintf("Can't read header of shortcuts file '%s'", shortcutsFname))
+	}
+	shortcutsLookup := NewCSVLookup(shortcutsHeader)
+	if err := shortcutsLookup.MustHave("from_vertex_id", "to_vertex_id", "weight", "via_vertex_id"); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Invalid shortcuts file '%s'", shortcutsFname))
 	}
 	// Read file line by line
 	for {
@@ -285,21 +305,21 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		if err == io.EOF {
 			break
 		}
-		sourceExternal, err := strconv.ParseInt(record[0], 10, 64)
+		sourceExternal, err := shortcutsLookup.Int64(record, "from_vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse source vertex in shortcuts file. The vertex is '%s'", record[0]))
+			return errors.Wrap(err, "shortcuts file")
 		}
-		targetExternal, err := strconv.ParseInt(record[1], 10, 64)
+		targetExternal, err := shortcutsLookup.Int64(record, "to_vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse target vertex in shortcuts file. The vertex is '%s'", record[1]))
+			return errors.Wrap(err, "shortcuts file")
 		}
-		weight, err := strconv.ParseFloat(record[2], 64)
+		weight, err := shortcutsLookup.Float64(record, "weight")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse weight of a shortcut in shortcuts file. The weight is '%s'", record[2]))
+			return errors.Wrap(err, "shortcuts file")
 		}
-		contractionExternal, err := strconv.ParseInt(record[3], 10, 64)
+		contractionExternal, err := shortcutsLookup.Int64(record, "via_vertex_id")
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Can't parse middle vertex of a shortcut in shortcuts file. The weight is '%s'", record[3]))
+			return errors.Wrap(err, "shortcuts file")
 		}
 		err = engine.graph.AddEdge(sourceExternal, targetExternal, weight)
 		if err != nil {


### PR DESCRIPTION
Preparation for replacing [`osm2ch`](https://github.com/LdDl/osm2ch) with [`osm2gmns`-based](https://github.com/LdDl/osm2gmns) graph generation. GMNS output has different column order and provides `length_meters` + `free_speed` instead of raw `weight`. This change makes horizon CSV-format-agnostic and enables time-based routing cost instead of distance-only.

- added `CSVLookup` utility for header-based CSV column access (replaces positional `record[N]` indexing)
- added `CostResolver` with fallback chain for edge cost calculation:
  - `weight` column (backward compat, priority)
  - `length_meters` + `free_speed`, then travel time in seconds
  - `length_meters` alone, then distance-based cost
  - none, then error
- migrated all CSV parsing in `map_engine.go` (edges, vertices, shortcuts) to use `CSVLookup`
- no breaking changes: existing CSV files from `osm2ch` work as before


p.s. in future I think more strategies for defining costs could be involved (basic one: parse geom and evaluate it's length + use defaults values for speed and so on)


