### PR TITLE
Fix same-edge transition when RoutingGraphVertex differs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ references_validation/
 *.prof
 *.test
 build/
+test_data_big/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Horizon v0.11.2 [![GoDoc](https://godoc.org/github.com/LdDl/horizon?status.svg)](https://godoc.org/github.com/LdDl/horizon) [![Build Status](https://travis-ci.com/LdDl/horizon.svg?branch=master)](https://travis-ci.com/LdDl/horizon) [![Sourcegraph](https://sourcegraph.com/github.com/LdDl/horizon/-/badge.svg)](https://sourcegraph.com/github.com/LdDl/horizon?badge) [![Go Report Card](https://goreportcard.com/badge/github.com/LdDl/horizon)](https://goreportcard.com/report/github.com/LdDl/horizon) [![GitHub tag](https://img.shields.io/github/tag/LdDl/horizon.svg)](https://github.com/LdDl/horizon/releases)
+# Horizon v0.11.3 [![GoDoc](https://godoc.org/github.com/LdDl/horizon?status.svg)](https://godoc.org/github.com/LdDl/horizon) [![Build Status](https://travis-ci.com/LdDl/horizon.svg?branch=master)](https://travis-ci.com/LdDl/horizon) [![Sourcegraph](https://sourcegraph.com/github.com/LdDl/horizon/-/badge.svg)](https://sourcegraph.com/github.com/LdDl/horizon?badge) [![Go Report Card](https://goreportcard.com/badge/github.com/LdDl/horizon)](https://goreportcard.com/report/github.com/LdDl/horizon) [![GitHub tag](https://img.shields.io/github/tag/LdDl/horizon.svg)](https://github.com/LdDl/horizon/releases)
 
 # Work in progress
 Horizon is project aimed to do map matching (snap GPS data to map) and routing (find shortest path between two points)
@@ -25,12 +25,12 @@ Demonstration:
 Via _go get_:
 ```shell
 go get github.com/LdDl/horizon
-go install github.com/LdDl/horizon/cmd/horizon@v0.11.2
+go install github.com/LdDl/horizon/cmd/horizon@v0.11.3
 ```
 
 Via downloading prebuilt binary and making updates in yours PATH environment varibale (both Linux and Windows):
-* Windows - https://github.com/LdDl/horizon/releases/download/v0.11.2/windows-horizon.zip
-* Linux - https://github.com/LdDl/horizon/releases/download/v0.11.2/linux-amd64-horizon.tar.gz
+* Windows - https://github.com/LdDl/horizon/releases/download/v0.11.3/windows-horizon.zip
+* Linux - https://github.com/LdDl/horizon/releases/download/v0.11.3/linux-amd64-horizon.tar.gz
 
 Check if **horizon** binary was installed properly:
 ```shell

--- a/map_engine.go
+++ b/map_engine.go
@@ -135,6 +135,25 @@ func prepareEngine(edgesFilename string) (*MapEngine, error) {
 	return engine, nil
 }
 
+// routeDistanceMeters sums LengthMeters of edges along a path (sequence of vertex IDs).
+// Used for transition probability which needs distance in meters, not time-based cost.
+func (engine *MapEngine) routeDistanceMeters(path []int64) float64 {
+	if len(path) < 2 {
+		return 0
+	}
+	totalMeters := 0.0
+	for i := 0; i < len(path)-1; i++ {
+		from := path[i]
+		to := path[i+1]
+		if targets, ok := engine.edges[from]; ok {
+			if edge, ok := targets[to]; ok {
+				totalMeters += edge.LengthMeters
+			}
+		}
+	}
+	return totalMeters
+}
+
 func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcutsFname string) error {
 	// Allocate memory for edges
 	engine.edges = make(map[int64]map[int64]*spatial.Edge)
@@ -207,12 +226,20 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		if _, ok := engine.edges[sourceVertex]; !ok {
 			engine.edges[sourceVertex] = make(map[int64]*spatial.Edge)
 		}
+		lengthMeters := weight // fallback: if no length_meters column, use weight
+		if edgesLookup.Has("length_meters") {
+			lengthMeters, err = edgesLookup.Float64(record, "length_meters")
+			if err != nil {
+				return errors.Wrap(err, "edges file: length_meters")
+			}
+		}
 		edge := spatial.Edge{
-			ID:       edgeID,
-			Source:   sourceVertex,
-			Target:   targetVertex,
-			Weight:   weight,
-			Polyline: s2Polyline,
+			ID:           edgeID,
+			Source:        sourceVertex,
+			Target:        targetVertex,
+			Weight:        weight,
+			LengthMeters: lengthMeters,
+			Polyline:     s2Polyline,
 		}
 		engine.edges[sourceVertex][targetVertex] = &edge
 

--- a/map_matcher.go
+++ b/map_matcher.go
@@ -278,42 +278,49 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 					} else {
 						// We should jump to source vertex of current state, since edges are not the same
 						rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].GraphEdge.Source)
-						var finalCost float64
+						var routeDistMeters float64
 						var finalPath []int64
 						if rawCost < 0 {
-							finalCost = math.MaxFloat64
+							routeDistMeters = math.MaxFloat64
 						} else {
-							// Apply candidate-specific penalty and copy path to avoid mutating cache
-							finalCost = rawCost + currentStates[n].GraphEdge.Weight
 							finalPath = make([]int64, len(rawPath), len(rawPath)+1)
 							copy(finalPath, rawPath)
 							finalPath = append(finalPath, currentStates[n].GraphEdge.Target)
+							routeDistMeters = matcher.engine.routeDistanceMeters(finalPath)
 						}
 						chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
-						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], finalCost)
+						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 					}
+					continue
+				}
+				// Same edge but different RoutingGraphVertex: use projected distance only if moving forward
+				// (beforeProjection increases => fraction increases => forward movement along the edge).
+				// If moving backward, the edge is likely a reverse-direction candidate — fall through to CH routing.
+				if prevStates[m].GraphEdge.ID == currentStates[n].GraphEdge.ID && prevStates[m].beforeProjection <= currentStates[n].beforeProjection {
+					ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
+					chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
+					currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], ans)
 					continue
 				}
 				rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].RoutingGraphVertex)
 
-				var finalCost float64
+				// Since we are doing Edge(target)-Edge(target) Dijkstra's call most of time we could:
+				// 1) add penalty for source edge by adding remaining distance to target vertex of source edge
+				// 2) add advantage for target edge by subtracting remaining distance to target vertex of target edge
+				// @todo: this could lead to negative values. Need to investigate when it happens
+				// finalCost = (finalCost + prevStates[m].afterProjection) - currentStates[n].afterProjection
+				var routeDistMeters float64
 				var finalPath []int64
 				if rawCost < 0 {
-					finalCost = math.MaxFloat64
+					routeDistMeters = math.MaxFloat64
 				} else {
-					// Apply candidate-specific penalty and copy path to avoid mutating cache
-					finalCost = rawCost + currentStates[n].GraphEdge.Weight
 					finalPath = make([]int64, len(rawPath), len(rawPath)+1)
 					copy(finalPath, rawPath)
 					finalPath = append(finalPath, currentStates[n].GraphEdge.Target)
-					// Since we are doing Edge(target)-Edge(target) Dijkstra's call most of time we could:
-					// 1) add penalty for source edge by adding remaining distance to target vertex of source edge
-					// 2) add advantage for target edge by subtracting remaining distance to target vertex of target edge
-					// @todo: this could lead to negative values. Need to investigate when it happens
-					// finalCost = (finalCost + prevStates[m].afterProjection) - currentStates[n].afterProjection
+					routeDistMeters = matcher.engine.routeDistanceMeters(finalPath)
 				}
 				chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
-				currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], finalCost)
+				currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 			}
 		}
 
@@ -626,7 +633,8 @@ func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentL
 				currentLayer.AddTransitionProbability(from, to, -ROUTE_LENGTH_THRESHOLD)
 				continue
 			}
-			transitionLogProbability, err := matcher.hmmParams.TransitionLogProbability(routeLengths[from.RoadPositionID][to.RoadPositionID], straightDistance, timeDiff)
+			rl := routeLengths[from.RoadPositionID][to.RoadPositionID]
+			transitionLogProbability, err := matcher.hmmParams.TransitionLogProbability(rl, straightDistance, timeDiff)
 			if err != nil {
 				return err
 			}

--- a/map_matcher_4326_small_test.go
+++ b/map_matcher_4326_small_test.go
@@ -26,16 +26,11 @@ func TestMapMatcherSRID_4326(t *testing.T) {
 				{
 					Observations: []ObservationResult{
 						{Observation: gpsMeasurements[0]},
-					},
-					Probability: -9.887810,
-				},
-				{
-					Observations: []ObservationResult{
 						{Observation: gpsMeasurements[1]},
 						{Observation: gpsMeasurements[2]},
 						{Observation: gpsMeasurements[3]},
 					},
-					Probability: -10000000025.753883,
+					Probability: -52.195440,
 				},
 			},
 		}
@@ -48,9 +43,9 @@ func TestMapMatcherSRID_4326(t *testing.T) {
 	}
 
 	correctStates.SubMatches[0].Observations[0].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[1].Observations[0].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[1].Observations[1].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[1].Observations[2].MatchedEdge = *matcher.engine.edges[102][105]
+	correctStates.SubMatches[0].Observations[1].MatchedEdge = *matcher.engine.edges[101][102]
+	correctStates.SubMatches[0].Observations[2].MatchedEdge = *matcher.engine.edges[101][102]
+	correctStates.SubMatches[0].Observations[3].MatchedEdge = *matcher.engine.edges[102][105]
 
 	statesRadiusMeters := 7.0
 	maxStates := 5

--- a/map_matcher_submatch_test.go
+++ b/map_matcher_submatch_test.go
@@ -204,7 +204,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 					{Observation: gpsMeasurements[0], MatchedEdge: *mapEngine.edges[0][1]},
 					{Observation: gpsMeasurements[1], MatchedEdge: *mapEngine.edges[2][3]},
 				},
-				Probability: -791.677435,
+				Probability: -1351.590679,
 			},
 			{
 				Observations: []ObservationResult{
@@ -218,7 +218,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 					{Observation: gpsMeasurements[4], MatchedEdge: *mapEngine.edges[9][10]},
 					{Observation: gpsMeasurements[5], MatchedEdge: *mapEngine.edges[10][11]},
 				},
-				Probability: -8100.966270,
+				Probability: -10137.429200,
 			},
 			{
 				Observations: []ObservationResult{
@@ -303,7 +303,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 
 	// 	for _, obs := range subMatch.Observations {
 	// 		// Add matched edge as LineString
-	// 		edgeFeature := S2PolylineToGeoJSONFeature(*obs.MatchedEdge.Polyline)
+	// 		edgeFeature := spatial.S2PolylineToGeoJSONFeature(*obs.MatchedEdge.Polyline)
 	// 		edgeFeature.SetProperty("type", "matched_edge")
 	// 		edgeFeature.SetProperty("submatch", s)
 	// 		edgeFeature.SetProperty("obs_id", obs.Observation.ID())
@@ -313,7 +313,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 	// 		fc.AddFeature(edgeFeature)
 
 	// 		// Add projected point
-	// 		projFeature := S2PointToGeoJSONFeature(&obs.ProjectedPoint)
+	// 		projFeature := spatial.S2PointToGeoJSONFeature(&obs.ProjectedPoint)
 	// 		projFeature.SetProperty("type", "projected_point")
 	// 		projFeature.SetProperty("submatch", s)
 	// 		projFeature.SetProperty("obs_id", obs.Observation.ID())

--- a/map_matcher_submatch_test.go
+++ b/map_matcher_submatch_test.go
@@ -162,11 +162,12 @@ func TestMapMatcherSubMatches(t *testing.T) {
 			s2.PointFromLatLng(targetPt),
 		}
 		edge := spatial.Edge{
-			ID:       edge.id,
-			Source:   edge.source,
-			Target:   edge.target,
-			Weight:   weight,
-			Polyline: &s2Polyline,
+			ID:           edge.id,
+			Source:        edge.source,
+			Target:        edge.target,
+			Weight:        weight,
+			LengthMeters: weight,
+			Polyline:     &s2Polyline,
 		}
 		edgesSpatial = append(edgesSpatial, &edge)
 	}
@@ -204,7 +205,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 					{Observation: gpsMeasurements[0], MatchedEdge: *mapEngine.edges[0][1]},
 					{Observation: gpsMeasurements[1], MatchedEdge: *mapEngine.edges[2][3]},
 				},
-				Probability: -1351.590679,
+				Probability: -791.677435,
 			},
 			{
 				Observations: []ObservationResult{
@@ -218,7 +219,7 @@ func TestMapMatcherSubMatches(t *testing.T) {
 					{Observation: gpsMeasurements[4], MatchedEdge: *mapEngine.edges[9][10]},
 					{Observation: gpsMeasurements[5], MatchedEdge: *mapEngine.edges[10][11]},
 				},
-				Probability: -10137.429200,
+				Probability: -8100.966270,
 			},
 			{
 				Observations: []ObservationResult{
@@ -512,11 +513,12 @@ func TestMapMatcherSubMatchesPlanar(t *testing.T) {
 			spatial.NewEuclideanS2Point(target[0], target[1]),
 		}
 		edge := spatial.Edge{
-			ID:       edge.id,
-			Source:   edge.source,
-			Target:   edge.target,
-			Weight:   weight,
-			Polyline: &s2Polyline,
+			ID:           edge.id,
+			Source:        edge.source,
+			Target:        edge.target,
+			Weight:        weight,
+			LengthMeters: weight,
+			Polyline:     &s2Polyline,
 		}
 		edgesSpatial = append(edgesSpatial, &edge)
 	}

--- a/spatial/edge.go
+++ b/spatial/edge.go
@@ -14,8 +14,9 @@ import (
 */
 type Edge struct {
 	*s2.Polyline
-	Weight float64
-	ID     int64
-	Source int64
-	Target int64
+	Weight       float64
+	LengthMeters float64
+	ID           int64
+	Source       int64
+	Target       int64
 }


### PR DESCRIPTION
fixed false sub-match breaks when consecutive GPS points project onto the same edge but are assigned different `RoutingGraphVertex` values. Previously the same-edge check was nested inside `RoutingGraphVertex ==`, making it unreachable for this case — CH routing would attempt a reverse path on a one-way edge, get infinite cost, and Viterbi would split the match.

Also added direction-aware same-edge handling: use projected distance only when `beforeProjection` increases (forward movement). Backward movement falls through to CH routing, preventing reverse-direction edges from becoming artificially cheap.

By the way, since [`osm2ch`](https://github.com/LdDl/osm2ch/releases/tag/v1.6.0) gives costs of travel in seconds we need to switch transition probability from time-based cost (`rawCost + edge.Weight`) to distance-based (`routeDistanceMeters`) for correct `|straightDistance - routeDistance|` computation.

And adde `LengthMeters` field to `spatial.Edge` for distance-based transition probability. Loaded from `length_meters` CSV column (osm2ch v1.6.0+, see above), falls back to `weight` if column is absent.
