### PR TITLE
Replace bubble sort with sort.Slice in hot paths

### DIFF
--- a/map_matcher.go
+++ b/map_matcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"sort"
 	"sync"
 
 	"github.com/LdDl/ch"
@@ -478,13 +479,9 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 	}
 
 	// Sort by first observation index
-	for i := 0; i < len(allSubMatches)-1; i++ {
-		for j := i + 1; j < len(allSubMatches); j++ {
-			if allSubMatches[i].firstObsIdx > allSubMatches[j].firstObsIdx {
-				allSubMatches[i], allSubMatches[j] = allSubMatches[j], allSubMatches[i]
-			}
-		}
-	}
+	sort.Slice(allSubMatches, func(i, j int) bool {
+		return allSubMatches[i].firstObsIdx < allSubMatches[j].firstObsIdx
+	})
 
 	// Extract sorted SubMatches
 	finalSubMatches := make([]SubMatch, len(allSubMatches))

--- a/map_matcher_simple_sp.go
+++ b/map_matcher_simple_sp.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"math"
+	"sort"
 
 	"github.com/LdDl/horizon/spatial"
 	"github.com/golang/geo/s2"
@@ -236,13 +237,9 @@ func (matcher *MapMatcher) findBestCandidatePair(sources, targets []candidateInf
 		}
 	}
 	// Sort by total distance
-	for i := 0; i < len(pairs)-1; i++ {
-		for j := i + 1; j < len(pairs); j++ {
-			if pairs[j].dist < pairs[i].dist {
-				pairs[i], pairs[j] = pairs[j], pairs[i]
-			}
-		}
-	}
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].dist < pairs[j].dist
+	})
 	// Try pairs in order until we find a routable one
 	for _, p := range pairs {
 		ans, _ := matcher.engine.queryPool.ShortestPath(p.src.vertex, p.tgt.vertex)


### PR DESCRIPTION
- Replace bubble sort (O(n^2)) with `sort.Slice` (O(n log n)) in `allSubMatches` sorting (`map_matcher.go`)
- Replace bubble sort with `sort.Slice` in `findBestCandidatePair` candidate pairs sorting (`map_matcher_simple_sp.go`)


| Benchmark | Before | After | Delta |
|---|---|---|---|
| 4326 small (4 pts) | ~57,000 ns/op | ~44,300 ns/op | **-22%** |
| 4326 big (10 pts) | ~5,620,000 ns/op | ~5,610,000 ns/op | ~0% (noise) |
| Routing | ~421,000 ns/op | ~415,000 ns/op | ~-1.5% |
