### PR TITLE
minor change on math hot path, index-based BFS

### DIFF
--- a/connected_components.go
+++ b/connected_components.go
@@ -24,11 +24,12 @@ func (engine *MapEngine) bfsMarkWeakComponent(start int64, componentID int64, vi
 	}
 
 	queue := []int64{start}
+	head := 0
 	size := 0
 
-	for len(queue) > 0 {
-		v := queue[0]
-		queue = queue[1:]
+	for head < len(queue) {
+		v := queue[head]
+		head++
 
 		if visited[v] {
 			continue

--- a/distributions.go
+++ b/distributions.go
@@ -12,14 +12,16 @@ var (
 
 // NormalDistribution https://en.wikipedia.org/wiki/Normal_distribution
 func NormalDistribution(sigma, x float64) float64 {
-	return 1.0 / (sqrtTwoPi * sigma) * math.Exp(-0.5*math.Pow(x/sigma, 2))
+	xOverSigma := x / sigma
+	return 1.0 / (sqrtTwoPi * sigma) * math.Exp(-0.5*xOverSigma*xOverSigma)
 }
 
 // LogNormalDistribution computes log of normal distribution PDF (normalized)
 // log(f(x)) = log(1/(sigma*sqrt(2*pi))) - 0.5*(x/sigma)^2
 // Note: Can return positive values when density > 1 (valid for PDFs)
 func LogNormalDistribution(sigma, x float64) float64 {
-	return math.Log(1.0/(sqrtTwoPi*sigma)) + (-0.5 * math.Pow(x/sigma, 2))
+	xOverSigma := x / sigma
+	return math.Log(1.0/(sqrtTwoPi*sigma)) + (-0.5 * xOverSigma * xOverSigma)
 }
 
 // LogNormalDistributionUnnormalized computes unnormalized log of normal distribution PDF
@@ -28,7 +30,8 @@ func LogNormalDistribution(sigma, x float64) float64 {
 // Reference: GraphHopper/OSRM implementations
 // Always returns values <= 0
 func LogNormalDistributionUnnormalized(sigma, x float64) float64 {
-	return -0.5 * math.Pow(x/sigma, 2)
+	xOverSigma := x / sigma
+	return -0.5 * xOverSigma * xOverSigma
 }
 
 // ExponentialDistribution computes (1/beta) * exp(-x/beta), where beta = 1/lambda

--- a/spatial/storage_spherical.go
+++ b/spatial/storage_spherical.go
@@ -90,17 +90,11 @@ func (storage *S2Storage) SearchInRadiusLonLat(lon, lat float64, radius float64)
 		if item != nil {
 			for _, edgeID := range item.(indexedItem).edgesInCell {
 				polyline := storage.edges[edgeID]
-				minEdge := s2.Edge{}
 				minDist := s1.ChordAngle(0)
 				for i := 0; i < polyline.Polyline.NumEdges(); i++ {
-					if i == 0 {
-						minEdge = polyline.Polyline.Edge(0)
-						minDist = cell.DistanceToEdge(minEdge.V0, minEdge.V1)
-						continue
-					}
 					edge := polyline.Polyline.Edge(i)
 					distance := cell.DistanceToEdge(edge.V0, edge.V1)
-					if distance < minDist {
+					if i == 0 || distance < minDist {
 						minDist = distance
 					}
 				}
@@ -139,17 +133,11 @@ func (storage *S2Storage) SearchInRadius(pt s2.Point, radius float64) (map[uint6
 		if item != nil {
 			for _, edgeID := range item.(indexedItem).edgesInCell {
 				polyline := storage.edges[edgeID]
-				minEdge := s2.Edge{}
 				minDist := s1.ChordAngle(0)
 				for i := 0; i < polyline.Polyline.NumEdges(); i++ {
-					if i == 0 {
-						minEdge = polyline.Polyline.Edge(0)
-						minDist = cell.DistanceToEdge(minEdge.V0, minEdge.V1)
-						continue
-					}
 					edge := polyline.Polyline.Edge(i)
 					distance := cell.DistanceToEdge(edge.V0, edge.V1)
-					if distance < minDist {
+					if i == 0 || distance < minDist {
 						minDist = distance
 					}
 				}


### PR DESCRIPTION
- removed dead `minEdge` variable in `SearchInRadius` / `SearchInRadiusLonLat` (redundant code)
- replace `math.Pow(x, 2)` with `x*x` in distribution functions (avoids generic exp/log path I believe)
- use index-based BFS queue instead of `queue[1:]` slice reslicing in `bfsMarkWeakComponent`

| Benchmark | Before (ns/op) | After (ns/op) | Delta | allocs before | allocs after |
|---|---|---|---|---|---|
| 4326BIG /1 pts | 5,602,481 | 6,039,374 | noise | 26,784 | **26,327** |
| 4326BIG /64 pts | 5,580,242 | 6,004,521 | noise | 26,791 | **26,324** |
| 4326BIG /4096 pts | 5,625,732 | 6,011,959 | noise | 26,788 | **26,326** |
| 4326 small /1 pts | 42,980 | 47,034 | noise | 308 | 309 |
| Routing Iter /1 | 413,486 | 420,613 | noise | 1,135 | 1,135 |