### PR TITLE
change CalcProjection sub-polyline allocation, extract buildFinalPath helper

### DIFF
--- a/map_matcher.go
+++ b/map_matcher.go
@@ -279,16 +279,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 					} else {
 						// We should jump to source vertex of current state, since edges are not the same
 						rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].GraphEdge.Source)
-						var routeDistMeters float64
-						var finalPath []int64
-						if rawCost < 0 {
-							routeDistMeters = math.MaxFloat64
-						} else {
-							finalPath = make([]int64, len(rawPath), len(rawPath)+1)
-							copy(finalPath, rawPath)
-							finalPath = append(finalPath, currentStates[n].GraphEdge.Target)
-							routeDistMeters = matcher.engine.routeDistanceMeters(finalPath)
-						}
+						routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
 						chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
 						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 					}
@@ -296,7 +287,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 				}
 				// Same edge but different RoutingGraphVertex: use projected distance only if moving forward
 				// (beforeProjection increases => fraction increases => forward movement along the edge).
-				// If moving backward, the edge is likely a reverse-direction candidate — fall through to CH routing.
+				// If moving backward, the edge is likely a reverse-direction candidate => fall through to CH routing.
 				if prevStates[m].GraphEdge.ID == currentStates[n].GraphEdge.ID && prevStates[m].beforeProjection <= currentStates[n].beforeProjection {
 					ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
 					chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
@@ -310,16 +301,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 				// 2) add advantage for target edge by subtracting remaining distance to target vertex of target edge
 				// @todo: this could lead to negative values. Need to investigate when it happens
 				// finalCost = (finalCost + prevStates[m].afterProjection) - currentStates[n].afterProjection
-				var routeDistMeters float64
-				var finalPath []int64
-				if rawCost < 0 {
-					routeDistMeters = math.MaxFloat64
-				} else {
-					finalPath = make([]int64, len(rawPath), len(rawPath)+1)
-					copy(finalPath, rawPath)
-					finalPath = append(finalPath, currentStates[n].GraphEdge.Target)
-					routeDistMeters = matcher.engine.routeDistanceMeters(finalPath)
-				}
+				routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
 				chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
 				currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 			}
@@ -683,4 +665,16 @@ func getCachedPath(queryPool *ch.QueryPool, vertexCache map[int64]map[int64]cach
 	}
 	vertexCache[fromVertex][toVertex] = cachedRoute{cost: rawCost, path: rawPath}
 	return rawCost, rawPath
+}
+
+// resolveRoute builds final path from cached CH result and computes route distance in meters.
+// rawPath comes from cache and must not be mutated, so a copy is made.
+func (matcher *MapMatcher) resolveRoute(rawCost float64, rawPath []int64, targetVertex int64) (float64, []int64) {
+	if rawCost < 0 {
+		return math.MaxFloat64, nil
+	}
+	finalPath := make([]int64, len(rawPath), len(rawPath)+1)
+	copy(finalPath, rawPath)
+	finalPath = append(finalPath, targetVertex)
+	return matcher.engine.routeDistanceMeters(finalPath), finalPath
 }

--- a/spatial/utils.go
+++ b/spatial/utils.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 	geojson "github.com/paulmach/go.geojson"
 )
@@ -21,12 +22,15 @@ import (
 */
 func CalcProjection(line s2.Polyline, point s2.Point) (projected s2.Point, fraction float64, next int) {
 	pr, next := line.Project(point)
-	subs := s2.Polyline{}
-	for i := 0; i < next; i++ {
-		subs = append(subs, line[i])
+	// Calculate length up to projection without allocating a sub-polyline
+	lengthToProj := s1.Angle(0)
+	for i := 0; i < next-1; i++ {
+		lengthToProj += line[i].Distance(line[i+1])
 	}
-	subs = append(subs, pr)
-	return pr, (subs.Length() / line.Length()).Radians(), next
+	if next > 0 {
+		lengthToProj += line[next-1].Distance(pr)
+	}
+	return pr, (lengthToProj / line.Length()).Radians(), next
 }
 
 // CalcProjectionEuclidean Returns projection on line and fraction for point (Euclidean/planar geometry)


### PR DESCRIPTION
- minor changes in `CalcProjection`: compute length to projected point by summing segment distances directly instead of allocating a temporary sub-polyline. Eliminates O(next) slice allocations per call.
- create `resolveRoute` utility function to deduplicate two identical `make+copy+append+routeDistanceMeters` code blocks (redundant) in the transition routing logic.

| Benchmark | Before | After | allocs before | allocs after | B/op before | B/op after |
|---|---|---|---|---|---|---|
| 4326BIG /1 pts | 6,022K ns | 6,126K ns (noise) | 26,327 | **26,198** | 2,691K | 2,676K |
| 4326 small /1 pts | 47,008 ns | 42,644 ns (**-9%**) | 309 | **289** | 22,448 | **21,176** |
| Routing Iter /1 | 424K ns | 427K ns (noise) | 1,135 | **1,085** | 276K | 276K |
| Routing WithRadius | 12,246K ns | 12,159K ns (noise) | 45,068 | **45,019** | 5,969K | 6,017K |

