### PR TITLE
[BUG] correct FindNearest early-exit to check n-th distance

### DIFF
--- a/spatial/storage_spherical.go
+++ b/spatial/storage_spherical.go
@@ -2,7 +2,6 @@ package spatial
 
 import (
 	"container/heap"
-	"sort"
 
 	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
@@ -204,6 +203,12 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 	visited := make(map[s2.CellID]bool)
 	found := make(map[uint64]float64)
 
+	// Bounded top-n tracker: keeps up to n smallest distances.
+	// topDists[topMaxIdx] is the n-th smallest (the largest among top-n).
+	// No interface boxing — O(n) insert, O(1) peek. n is small (typically 5-10).
+	topDists := make([]float64, 0, n)
+	topMaxIdx := 0
+
 	// Frontier-based expansion: start with center cell
 	frontier := []s2.CellID{centerCell}
 	visited[centerCell] = true
@@ -237,16 +242,32 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 						minDist = distance
 					}
 				}
-				found[edgeID] = minDist.Angle().Radians() * EarthRadius
+				dist := minDist.Angle().Radians() * EarthRadius
+				found[edgeID] = dist
+
+				// Maintain bounded top-n tracker
+				if len(topDists) < n {
+					topDists = append(topDists, dist)
+					if dist > topDists[topMaxIdx] {
+						topMaxIdx = len(topDists) - 1
+					}
+				} else if dist < topDists[topMaxIdx] {
+					topDists[topMaxIdx] = dist
+					// Rescan for new max (n is small, typically 5-10)
+					for j := range topDists {
+						if topDists[j] > topDists[topMaxIdx] {
+							topMaxIdx = j
+						}
+					}
+				}
 			}
 		}
 
 		// Early exit: stop when the n-th closest edge is closer than the ring boundary.
-		// This guarantees no unexplored ring can contain a closer candidate.
-		if len(found) >= n && ring > 0 {
+		// topDists[topMaxIdx] is the largest among top-n = the n-th smallest distance.
+		if len(topDists) >= n && ring > 0 {
 			ringRadius := cellSize * float64(ring)
-			nthDist := nthSmallestDist(found, n)
-			if nthDist < ringRadius {
+			if topDists[topMaxIdx] < ringRadius {
 				break
 			}
 		}
@@ -273,7 +294,7 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 		frontier = nextFrontier
 	}
 
-	// Build result using heap for top-N selection
+	// Build result from found map using min-heap for top-N selection
 	h := &nearestHeap{}
 	heap.Init(h)
 	for k, v := range found {
@@ -368,19 +389,4 @@ func (storage *S2Storage) cellSizeMeters() float64 {
 	// Level 0: ~9000 km, Level 10: ~10 km, Level 15: ~300 m, Level 20: ~10 m, Level 30: ~1 cm
 	// Formula: size ≈ 9000km / 2^level
 	return 9000000.0 / float64(uint64(1)<<uint(storage.storageLevel))
-}
-
-// nthSmallestDist returns the n-th smallest distance value from the map.
-// Used for early-exit: we can stop expanding rings when the n-th closest
-// candidate is closer than the ring boundary (no unexplored ring can improve top-N).
-func nthSmallestDist(found map[uint64]float64, n int) float64 {
-	dists := make([]float64, 0, len(found))
-	for _, d := range found {
-		dists = append(dists, d)
-	}
-	sort.Float64s(dists)
-	if n > len(dists) {
-		return dists[len(dists)-1]
-	}
-	return dists[n-1]
 }

--- a/spatial/storage_spherical.go
+++ b/spatial/storage_spherical.go
@@ -2,6 +2,7 @@ package spatial
 
 import (
 	"container/heap"
+	"sort"
 
 	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
@@ -240,20 +241,12 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 			}
 		}
 
-		// Early exit check
+		// Early exit: stop when the n-th closest edge is closer than the ring boundary.
+		// This guarantees no unexplored ring can contain a closer candidate.
 		if len(found) >= n && ring > 0 {
 			ringRadius := cellSize * float64(ring)
-
-			// Find minimum distance among candidates
-			minFoundDist := float64(1e18)
-			for _, dist := range found {
-				if dist < minFoundDist {
-					minFoundDist = dist
-				}
-			}
-
-			// If closest edge is closer than ring boundary, we can stop
-			if minFoundDist < ringRadius {
+			nthDist := nthSmallestDist(found, n)
+			if nthDist < ringRadius {
 				break
 			}
 		}
@@ -375,4 +368,19 @@ func (storage *S2Storage) cellSizeMeters() float64 {
 	// Level 0: ~9000 km, Level 10: ~10 km, Level 15: ~300 m, Level 20: ~10 m, Level 30: ~1 cm
 	// Formula: size ≈ 9000km / 2^level
 	return 9000000.0 / float64(uint64(1)<<uint(storage.storageLevel))
+}
+
+// nthSmallestDist returns the n-th smallest distance value from the map.
+// Used for early-exit: we can stop expanding rings when the n-th closest
+// candidate is closer than the ring boundary (no unexplored ring can improve top-N).
+func nthSmallestDist(found map[uint64]float64, n int) float64 {
+	dists := make([]float64, 0, len(found))
+	for _, d := range found {
+		dists = append(dists, d)
+	}
+	sort.Float64s(dists)
+	if n > len(dists) {
+		return dists[len(dists)-1]
+	}
+	return dists[n-1]
 }


### PR DESCRIPTION
Fixed FindNearest early-exit condition: check n-th smallest distance against ring boundary instead of minimum distance. Old code could exit too early - if the closest edge was found but the n-th closest was still in an unexplored ring, it would be missed

Now bounded top-n tracker (zero-alloc, O(n) insert) is used instead of per-ring sort+allocation

| Metric | Before | After | Delta |
|--------|--------|-----|---|
| Routing ns/op | ~418K | ~510K | +22% |
| Routing allocs | 1085 | 1274 | +189 |
| Routing_WithRadius ns/op | ~14.3M | ~14.4M | ~0% |
| MapMatcher 4326 BIG ns/op | ~6.7M | ~6.7M | ~0% |

Note on regression: +22% on Routing is the inherent cost of correctness - the fixed early-exit checks the n-th distance (>= min distance), so more S2 cell rings are explored before termination. The old code exited prematurely, potentially returning fewer than n nearest edges. The regression does not affect radius-based search or map matching.

