### PR TITLE
iterative Tarjan SCC to avoid stack overflow on large graphs

### DIFF
--- a/strong_components.go
+++ b/strong_components.go
@@ -1,7 +1,5 @@
 package horizon
 
-import "github.com/LdDl/horizon/spatial"
-
 // Strongly Connected Components (SCC) are used instead of Weakly Connected Components
 // for routing candidate selection. The key difference:
 //
@@ -66,20 +64,16 @@ func newTarjanState() *tarjanState {
 // tarjanFrame represents a single stack frame for iterative Tarjan's DFS.
 // It replaces the recursive call stack: vertex being processed + position in its neighbor list.
 type tarjanFrame struct {
-	v         int64
-	neighbors []int64 // pre-collected neighbor keys (map iteration can't be paused)
-	pos       int     // next neighbor index to process
+	v   int64
+	pos int // next neighbor index to process in adjacency[v]
 }
 
 // strongConnect is the iterative DFS function for Tarjan's algorithm.
 // Uses an explicit call stack to avoid Go stack growth overhead on large graphs.
-func (engine *MapEngine) strongConnect(root int64, state *tarjanState) {
+// adjacency is a pre-built map of vertex -> []neighbor (built once, shared across calls).
+func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency map[int64][]int64) {
 	// Initialize root frame
-	callStack := []tarjanFrame{{
-		v:         root,
-		neighbors: edgeKeys(engine.edges[root]),
-		pos:       0,
-	}}
+	callStack := []tarjanFrame{{v: root, pos: 0}}
 	state.indexMap[root] = state.index
 	state.lowLink[root] = state.index
 	state.index++
@@ -88,9 +82,10 @@ func (engine *MapEngine) strongConnect(root int64, state *tarjanState) {
 
 	for len(callStack) > 0 {
 		frame := &callStack[len(callStack)-1]
+		neighbors := adjacency[frame.v]
 
-		if frame.pos < len(frame.neighbors) {
-			neighbor := frame.neighbors[frame.pos]
+		if frame.pos < len(neighbors) {
+			neighbor := neighbors[frame.pos]
 			frame.pos++
 
 			if _, visited := state.indexMap[neighbor]; !visited {
@@ -101,11 +96,7 @@ func (engine *MapEngine) strongConnect(root int64, state *tarjanState) {
 				state.stack = append(state.stack, neighbor)
 				state.onStack[neighbor] = true
 
-				callStack = append(callStack, tarjanFrame{
-					v:         neighbor,
-					neighbors: edgeKeys(engine.edges[neighbor]),
-					pos:       0,
-				})
+				callStack = append(callStack, tarjanFrame{v: neighbor, pos: 0})
 			} else if state.onStack[neighbor] {
 				if state.indexMap[neighbor] < state.lowLink[frame.v] {
 					state.lowLink[frame.v] = state.indexMap[neighbor]
@@ -142,37 +133,30 @@ func (engine *MapEngine) strongConnect(root int64, state *tarjanState) {
 	}
 }
 
-// edgeKeys returns the keys of a map as a slice.
-func edgeKeys(m map[int64]*spatial.Edge) []int64 {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]int64, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // computeStrongConnectedComponents finds all strongly connected components using Tarjan's algorithm.
 // A strongly connected component is a maximal set of vertices where every vertex
 // can reach every other vertex via directed paths. See the ref. https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
 func (engine *MapEngine) computeStrongConnectedComponents() StrongComponentsResult {
 	state := newTarjanState()
 
-	// Collect all vertices
+	// Pre-build adjacency list: map iteration can't be paused/resumed,
+	// so we convert map[int64]*Edge to []int64 once, shared across all strongConnect calls.
+	adjacency := make(map[int64][]int64, len(engine.edges))
 	vertices := make(map[int64]bool)
 	for src, targets := range engine.edges {
 		vertices[src] = true
+		neighbors := make([]int64, 0, len(targets))
 		for dst := range targets {
 			vertices[dst] = true
+			neighbors = append(neighbors, dst)
 		}
+		adjacency[src] = neighbors
 	}
 
 	// Run Tarjan's algorithm from each unvisited vertex
 	for v := range vertices {
 		if _, visited := state.indexMap[v]; !visited {
-			engine.strongConnect(v, state)
+			engine.strongConnect(v, state, adjacency)
 		}
 	}
 

--- a/strong_components.go
+++ b/strong_components.go
@@ -1,5 +1,7 @@
 package horizon
 
+import "github.com/LdDl/horizon/spatial"
+
 // Strongly Connected Components (SCC) are used instead of Weakly Connected Components
 // for routing candidate selection. The key difference:
 //
@@ -61,45 +63,95 @@ func newTarjanState() *tarjanState {
 	}
 }
 
-// strongConnect is the recursive DFS function for Tarjan's algorithm
-func (engine *MapEngine) strongConnect(v int64, state *tarjanState) {
-	// Set the depth index for v to the smallest unused index
-	state.indexMap[v] = state.index
-	state.lowLink[v] = state.index
+// tarjanFrame represents a single stack frame for iterative Tarjan's DFS.
+// It replaces the recursive call stack: vertex being processed + position in its neighbor list.
+type tarjanFrame struct {
+	v         int64
+	neighbors []int64 // pre-collected neighbor keys (map iteration can't be paused)
+	pos       int     // next neighbor index to process
+}
+
+// strongConnect is the iterative DFS function for Tarjan's algorithm.
+// Uses an explicit call stack to avoid Go stack growth overhead on large graphs.
+func (engine *MapEngine) strongConnect(root int64, state *tarjanState) {
+	// Initialize root frame
+	callStack := []tarjanFrame{{
+		v:         root,
+		neighbors: edgeKeys(engine.edges[root]),
+		pos:       0,
+	}}
+	state.indexMap[root] = state.index
+	state.lowLink[root] = state.index
 	state.index++
-	state.stack = append(state.stack, v)
-	state.onStack[v] = true
+	state.stack = append(state.stack, root)
+	state.onStack[root] = true
 
-	// Consider successors of v (only outgoing edges for SCC)
-	for neighbor := range engine.edges[v] {
-		if _, visited := state.indexMap[neighbor]; !visited {
-			// Successor has not yet been visited; recurse on it
-			engine.strongConnect(neighbor, state)
-			if state.lowLink[neighbor] < state.lowLink[v] {
-				state.lowLink[v] = state.lowLink[neighbor]
+	for len(callStack) > 0 {
+		frame := &callStack[len(callStack)-1]
+
+		if frame.pos < len(frame.neighbors) {
+			neighbor := frame.neighbors[frame.pos]
+			frame.pos++
+
+			if _, visited := state.indexMap[neighbor]; !visited {
+				// "Recurse": push new frame
+				state.indexMap[neighbor] = state.index
+				state.lowLink[neighbor] = state.index
+				state.index++
+				state.stack = append(state.stack, neighbor)
+				state.onStack[neighbor] = true
+
+				callStack = append(callStack, tarjanFrame{
+					v:         neighbor,
+					neighbors: edgeKeys(engine.edges[neighbor]),
+					pos:       0,
+				})
+			} else if state.onStack[neighbor] {
+				if state.indexMap[neighbor] < state.lowLink[frame.v] {
+					state.lowLink[frame.v] = state.indexMap[neighbor]
+				}
 			}
-		} else if state.onStack[neighbor] {
-			// Successor is on stack and hence in the current SCC
-			if state.indexMap[neighbor] < state.lowLink[v] {
-				state.lowLink[v] = state.indexMap[neighbor]
+		} else {
+			// All neighbors processed — "return" from this frame
+			v := frame.v
+			callStack = callStack[:len(callStack)-1]
+
+			// Post-order: update parent's lowLink (equivalent to after recursive call returns)
+			if len(callStack) > 0 {
+				parent := &callStack[len(callStack)-1]
+				if state.lowLink[v] < state.lowLink[parent.v] {
+					state.lowLink[parent.v] = state.lowLink[v]
+				}
+			}
+
+			// If v is a root node, pop the SCC stack and generate a component
+			if state.lowLink[v] == state.indexMap[v] {
+				component := make([]int64, 0)
+				for {
+					w := state.stack[len(state.stack)-1]
+					state.stack = state.stack[:len(state.stack)-1]
+					state.onStack[w] = false
+					component = append(component, w)
+					if w == v {
+						break
+					}
+				}
+				state.components = append(state.components, component)
 			}
 		}
 	}
+}
 
-	// If v is a root node, pop the stack and generate an SCC
-	if state.lowLink[v] == state.indexMap[v] {
-		component := make([]int64, 0)
-		for {
-			w := state.stack[len(state.stack)-1]
-			state.stack = state.stack[:len(state.stack)-1]
-			state.onStack[w] = false
-			component = append(component, w)
-			if w == v {
-				break
-			}
-		}
-		state.components = append(state.components, component)
+// edgeKeys returns the keys of a map as a slice.
+func edgeKeys(m map[int64]*spatial.Edge) []int64 {
+	if len(m) == 0 {
+		return nil
 	}
+	keys := make([]int64, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 // computeStrongConnectedComponents finds all strongly connected components using Tarjan's algorithm.

--- a/strong_components.go
+++ b/strong_components.go
@@ -139,18 +139,26 @@ func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency
 func (engine *MapEngine) computeStrongConnectedComponents() StrongComponentsResult {
 	state := newTarjanState()
 
-	// Pre-build adjacency list: map iteration can't be paused/resumed,
-	// so we convert map[int64]*Edge to []int64 once, shared across all strongConnect calls.
-	adjacency := make(map[int64][]int64, len(engine.edges))
+	// Pre-build flat adjacency list (CSR-style): one allocation for all neighbor data.
+	// adjacencyFlat holds all neighbor IDs concatenated; adjacency[v] is a sub-slice into it.
+	// This replaces 40k+ individual slice allocations with a single flat buffer.
+	totalEdges := 0
 	vertices := make(map[int64]bool)
 	for src, targets := range engine.edges {
 		vertices[src] = true
-		neighbors := make([]int64, 0, len(targets))
+		totalEdges += len(targets)
 		for dst := range targets {
 			vertices[dst] = true
-			neighbors = append(neighbors, dst)
 		}
-		adjacency[src] = neighbors
+	}
+	adjacencyFlat := make([]int64, 0, totalEdges)
+	adjacency := make(map[int64][]int64, len(engine.edges))
+	for src, targets := range engine.edges {
+		start := len(adjacencyFlat)
+		for dst := range targets {
+			adjacencyFlat = append(adjacencyFlat, dst)
+		}
+		adjacency[src] = adjacencyFlat[start:len(adjacencyFlat):len(adjacencyFlat)]
 	}
 
 	// Run Tarjan's algorithm from each unvisited vertex

--- a/strong_components.go
+++ b/strong_components.go
@@ -133,6 +133,7 @@ func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency
 			}
 		}
 	}
+	return callStack
 }
 
 // computeStrongConnectedComponents finds all strongly connected components using Tarjan's algorithm.
@@ -163,10 +164,12 @@ func (engine *MapEngine) computeStrongConnectedComponents() StrongComponentsResu
 		adjacency[src] = adjacencyFlat[start:len(adjacencyFlat):len(adjacencyFlat)]
 	}
 
-	// Run Tarjan's algorithm from each unvisited vertex
+	// Run Tarjan's algorithm from each unvisited vertex.
+	// callStack is reused across calls to avoid repeated allocations.
+	callStack := make([]tarjanFrame, 0, 256)
 	for v := range vertices {
 		if _, visited := state.indexMap[v]; !visited {
-			engine.strongConnect(v, state, adjacency)
+			callStack = engine.strongConnect(v, state, adjacency, callStack)
 		}
 	}
 

--- a/strong_components.go
+++ b/strong_components.go
@@ -71,9 +71,10 @@ type tarjanFrame struct {
 // strongConnect is the iterative DFS function for Tarjan's algorithm.
 // Uses an explicit call stack to avoid Go stack growth overhead on large graphs.
 // adjacency is a pre-built map of vertex -> []neighbor (built once, shared across calls).
-func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency map[int64][]int64) {
-	// Initialize root frame with pre-allocated capacity
-	callStack := make([]tarjanFrame, 1, 256)
+// callStack is a reusable buffer to avoid repeated allocations across calls.
+func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency map[int64][]int64, callStack []tarjanFrame) []tarjanFrame {
+	// Reset and initialize root frame
+	callStack = callStack[:1]
 	callStack[0] = tarjanFrame{v: root, pos: 0}
 	state.indexMap[root] = state.index
 	state.lowLink[root] = state.index

--- a/strong_components.go
+++ b/strong_components.go
@@ -72,8 +72,9 @@ type tarjanFrame struct {
 // Uses an explicit call stack to avoid Go stack growth overhead on large graphs.
 // adjacency is a pre-built map of vertex -> []neighbor (built once, shared across calls).
 func (engine *MapEngine) strongConnect(root int64, state *tarjanState, adjacency map[int64][]int64) {
-	// Initialize root frame
-	callStack := []tarjanFrame{{v: root, pos: 0}}
+	// Initialize root frame with pre-allocated capacity
+	callStack := make([]tarjanFrame, 1, 256)
+	callStack[0] = tarjanFrame{v: root, pos: 0}
 	state.indexMap[root] = state.index
 	state.lowLink[root] = state.index
 	state.index++

--- a/strong_components_benchmark_test.go
+++ b/strong_components_benchmark_test.go
@@ -1,0 +1,28 @@
+package horizon
+
+import (
+	"testing"
+)
+
+// BenchmarkSCC benchmarks computeStrongConnectedComponents on osm2ch_export.csv graph.
+func BenchmarkSCC(b *testing.B) {
+	graphFileName := "./test_data/osm2ch_export.csv"
+
+	b.Log("Loading graph...")
+	hmmParams := NewHmmProbabilities(50.0, 30.0)
+	matcher, err := NewMapMatcherFromFiles(hmmParams, graphFileName)
+	if err != nil {
+		b.Fatalf("Failed to load graph: %v", err)
+	}
+
+	b.Logf("Graph has %d source vertices in edges map", len(matcher.engine.edges))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := matcher.engine.computeStrongConnectedComponents()
+		if result.TotalComponents == 0 {
+			b.Fatal("Expected at least 1 component")
+		}
+	}
+}


### PR DESCRIPTION
recursive Tarjan risks uncontrolled Go stack growth on city-scale graphs with deep DFS chains (100k+ vertices). Iterative version bounds memory explicitly so I've replaced recursive `strongConnect` with iterative version using explicit call stack:
- Pre-build flat adjacency list (CSR-style) - single allocation instead of per-vertex map iteration
- Reuse call stack buffer across `strongConnect` invocations


| Metric | Before | After | Delta |
|--------|-------------------|-----------|---|
| ns/op | 36,351,165 | 36,121,026 | -0.6% |
| B/op | 15,507,960 | 19,277,907 | +24% |
| allocs/op | 8,058 | 8,198 | +1.7% |

graph has 40k vertices: time and allocs are changed barely. Also +3.8MB is the one-time cost of the flat adjacency buffer - negligible compared to the graph itself.
