### PR TITLE
flat maps + polyline caching + bbox pruning

### DIFF
--- a/candidates.go
+++ b/candidates.go
@@ -11,16 +11,12 @@ type transition struct {
 	prob float64
 }
 
-type lengths map[int]map[int]float64
+type lengths map[[2]int]float64
 
 func (m lengths) AddRouteLength(from, to *RoadPosition, routeLength float64) {
-	if _, ok := m[from.RoadPositionID]; !ok {
-		m[from.RoadPositionID] = make(map[int]float64)
-		m[from.RoadPositionID][to.RoadPositionID] = routeLength
-	} else {
-		if _, ok := m[from.RoadPositionID][to.RoadPositionID]; !ok {
-			m[from.RoadPositionID][to.RoadPositionID] = routeLength
-		}
+	key := [2]int{from.RoadPositionID, to.RoadPositionID}
+	if _, ok := m[key]; !ok {
+		m[key] = routeLength
 	}
 }
 

--- a/connected_components.go
+++ b/connected_components.go
@@ -39,9 +39,9 @@ func (engine *MapEngine) bfsMarkWeakComponent(start int64, componentID int64, vi
 		size++
 
 		// Add neighbors via outgoing edges (v -> neighbor)
-		for neighbor := range engine.edges[v] {
-			if !visited[neighbor] {
-				queue = append(queue, neighbor)
+		for _, entry := range engine.edges.Neighbors(v) {
+			if !visited[entry.Target] {
+				queue = append(queue, entry.Target)
 			}
 		}
 
@@ -73,11 +73,11 @@ func (engine *MapEngine) computeWeakConnectedComponents() WeakComponentsResult {
 	// This allows O(degree) lookup for incoming edges instead of O(E)
 	reverseEdges := make(map[int64][]int64)
 	vertices := make(map[int64]bool)
-	for src, targets := range engine.edges {
+	for src, entries := range engine.edges.Adj() {
 		vertices[src] = true
-		for dst := range targets {
-			vertices[dst] = true
-			reverseEdges[dst] = append(reverseEdges[dst], src)
+		for _, entry := range entries {
+			vertices[entry.Target] = true
+			reverseEdges[entry.Target] = append(reverseEdges[entry.Target], src)
 		}
 	}
 

--- a/connected_components_test.go
+++ b/connected_components_test.go
@@ -8,21 +8,21 @@ import (
 
 func TestBfsMarkWeakComponent(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create a simple graph:
 	// Component 1: 1 -> 2 -> 3
 	// Component 2: 4 -> 5 (isolated from component 1)
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{3: {}}
-	engine.edges[4] = map[int64]*spatial.Edge{5: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 3, &spatial.Edge{})
+	engine.edges.Set(4, 5, &spatial.Edge{})
 
 	// Build reverse edges index
 	reverseEdges := make(map[int64][]int64)
-	for src, targets := range engine.edges {
-		for dst := range targets {
-			reverseEdges[dst] = append(reverseEdges[dst], src)
+	for src, entries := range engine.edges.Adj() {
+		for _, entry := range entries {
+			reverseEdges[entry.Target] = append(reverseEdges[entry.Target], src)
 		}
 	}
 
@@ -58,20 +58,20 @@ func TestBfsMarkWeakComponent(t *testing.T) {
 
 func TestBfsMarkWeakComponentUndirected(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create a graph where vertices are connected only via incoming edges:
 	// 1 -> 2, 3 -> 2
 	// Starting from vertex 3, we should still reach 1 and 2 (undirected traversal)
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[3] = map[int64]*spatial.Edge{2: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(3, 2, &spatial.Edge{})
 
 	// Build reverse edges index
 	reverseEdges := make(map[int64][]int64)
-	for src, targets := range engine.edges {
-		for dst := range targets {
-			reverseEdges[dst] = append(reverseEdges[dst], src)
+	for src, entries := range engine.edges.Adj() {
+		for _, entry := range entries {
+			reverseEdges[entry.Target] = append(reverseEdges[entry.Target], src)
 		}
 	}
 
@@ -97,16 +97,16 @@ func TestBfsMarkWeakComponentUndirected(t *testing.T) {
 
 func TestBfsMarkWeakComponentAlreadyVisited(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
 
 	// Build reverse edges index
 	reverseEdges := make(map[int64][]int64)
-	for src, targets := range engine.edges {
-		for dst := range targets {
-			reverseEdges[dst] = append(reverseEdges[dst], src)
+	for src, entries := range engine.edges.Adj() {
+		for _, entry := range entries {
+			reverseEdges[entry.Target] = append(reverseEdges[entry.Target], src)
 		}
 	}
 
@@ -125,18 +125,18 @@ func TestBfsMarkWeakComponentAlreadyVisited(t *testing.T) {
 
 func TestComputeWeakConnectedComponents(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create graph with 3 components:
 	// Component A: 1 -> 2 -> 3 -> 4 (size 4, biggest)
 	// Component B: 10 -> 11 (size 2)
 	// Component C: 20 (isolated vertex with self-loop or outgoing edge to nowhere)
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{3: {}}
-	engine.edges[3] = map[int64]*spatial.Edge{4: {}}
-	engine.edges[10] = map[int64]*spatial.Edge{11: {}}
-	engine.edges[20] = map[int64]*spatial.Edge{21: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 3, &spatial.Edge{})
+	engine.edges.Set(3, 4, &spatial.Edge{})
+	engine.edges.Set(10, 11, &spatial.Edge{})
+	engine.edges.Set(20, 21, &spatial.Edge{})
 
 	result := engine.computeWeakConnectedComponents()
 

--- a/edge_graph.go
+++ b/edge_graph.go
@@ -1,0 +1,63 @@
+package horizon
+
+import "github.com/LdDl/horizon/spatial"
+
+// EdgeEntry represents a single outgoing edge in the adjacency list.
+type EdgeEntry struct {
+	Target int64
+	Edge   *spatial.Edge
+}
+
+// EdgeGraph stores edges in a flat lookup map (keyed by [source, target])
+// plus an adjacency list for neighbor iteration. This replaces the nested
+// map[int64]map[int64]*spatial.Edge for better cache locality, fewer allocations,
+// and single hash lookup instead of two.
+type EdgeGraph struct {
+	lookup map[[2]int64]*spatial.Edge
+	adj    map[int64][]EdgeEntry
+}
+
+// NewEdgeGraph creates an empty EdgeGraph.
+func NewEdgeGraph() *EdgeGraph {
+	return &EdgeGraph{
+		lookup: make(map[[2]int64]*spatial.Edge),
+		adj:    make(map[int64][]EdgeEntry),
+	}
+}
+
+// Set adds or replaces an edge from src to dst.
+func (g *EdgeGraph) Set(src, dst int64, edge *spatial.Edge) {
+	key := [2]int64{src, dst}
+	if _, exists := g.lookup[key]; !exists {
+		g.adj[src] = append(g.adj[src], EdgeEntry{Target: dst, Edge: edge})
+	} else {
+		// Update existing entry in adjacency list
+		for i := range g.adj[src] {
+			if g.adj[src][i].Target == dst {
+				g.adj[src][i].Edge = edge
+				break
+			}
+		}
+	}
+	g.lookup[key] = edge
+}
+
+// Get returns the edge from src to dst, or nil if not found.
+func (g *EdgeGraph) Get(src, dst int64) *spatial.Edge {
+	return g.lookup[[2]int64{src, dst}]
+}
+
+// Neighbors returns all outgoing edges from src.
+func (g *EdgeGraph) Neighbors(src int64) []EdgeEntry {
+	return g.adj[src]
+}
+
+// Adj returns the full adjacency map (for iterating all sources).
+func (g *EdgeGraph) Adj() map[int64][]EdgeEntry {
+	return g.adj
+}
+
+// Len returns the number of source vertices that have outgoing edges.
+func (g *EdgeGraph) Len() int {
+	return len(g.adj)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ toolchain go1.24.1
 
 require (
 	github.com/LdDl/ch v1.10.0
-	github.com/LdDl/viterbi v1.1.1
+	github.com/LdDl/viterbi v1.2.0
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
 	github.com/google/btree v1.0.0
 	github.com/paulmach/go.geojson v1.4.0
 	github.com/pkg/errors v0.9.1
+	github.com/tidwall/rtree v1.10.0
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.5
 )
@@ -25,7 +26,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tidwall/geoindex v1.7.0 // indirect
-	github.com/tidwall/rtree v1.10.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.55.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,11 @@
-github.com/LdDl/ch v1.7.7 h1:jTrqlG0IaTEnL9AUL6TOCsybHKtUwEm+I1sdvL6owsk=
-github.com/LdDl/ch v1.7.7/go.mod h1:i6JXvviI4GnJRTctKKVo6A0PzqaxaTHKvXhHgqVwFRY=
 github.com/LdDl/ch v1.10.0 h1:lmnLWoDBeDed2BAF8bSXYM0gqhSWH/x8sGpq9BC8zEo=
 github.com/LdDl/ch v1.10.0/go.mod h1:avoHwCjqiij6aV1IJt/FoOkGgNJQt4sRhU8Q3CRGoEk=
-github.com/LdDl/viterbi v1.1.0 h1:P+NdpZpktXCULL/fdvA0sRzf6wPmjhunDZ9JFFirmws=
-github.com/LdDl/viterbi v1.1.0/go.mod h1:aRi/jFMBD9c+rhe0/iIlO1QAiQn6Yo5K79aKBzp1HMg=
-github.com/LdDl/viterbi v1.1.1 h1:6n4AcBWdmVM5RaOcdH0fRvzYWh1bDXDHkb+DjiYwG1M=
-github.com/LdDl/viterbi v1.1.1/go.mod h1:aRi/jFMBD9c+rhe0/iIlO1QAiQn6Yo5K79aKBzp1HMg=
+github.com/LdDl/viterbi v1.2.0 h1:zGXLRP7ayHm985RO1LM/OHMlPapWlUnjXAP3j2Q6o7o=
+github.com/LdDl/viterbi v1.2.0/go.mod h1:aRi/jFMBD9c+rhe0/iIlO1QAiQn6Yo5K79aKBzp1HMg=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -39,6 +36,7 @@ github.com/paulmach/go.geojson v1.4.0 h1:5x5moCkCtDo5x8af62P9IOAYGQcYHtxz2QJ3x1D
 github.com/paulmach/go.geojson v1.4.0/go.mod h1:YaKx1hKpWF+T2oj2lFJPsW/t1Q5e1jQI61eoQSTwpIs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -50,10 +48,13 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/cities v0.1.0 h1:CVNkmMf7NEC9Bvokf5GoSsArHCKRMTgLuubRTHnH0mE=
 github.com/tidwall/cities v0.1.0/go.mod h1:lV/HDp2gCcRcHJWqgt6Di54GiDrTZwh1aG2ZUPNbqa4=
 github.com/tidwall/geoindex v1.7.0 h1:jtk41sfgwIt8MEDyC3xyKSj75iXXf6rjReJGDNPtR5o=
 github.com/tidwall/geoindex v1.7.0/go.mod h1:rvVVNEFfkJVWGUdEfU8QaoOg/9zFX0h9ofWzA60mz1I=
+github.com/tidwall/lotsa v1.0.2 h1:dNVBH5MErdaQ/xd9s769R31/n2dXavsQ0Yf4TMEHHw8=
 github.com/tidwall/lotsa v1.0.2/go.mod h1:X6NiU+4yHA3fE3Puvpnn1XMDrFZrE9JO2/w+UMuqgR8=
 github.com/tidwall/rtree v1.10.0 h1:+EcI8fboEaW1L3/9oW/6AMoQ8HiEIHyR7bQOGnmz4Mg=
 github.com/tidwall/rtree v1.10.0/go.mod h1:iDJQ9NBRtbfKkzZu02za+mIlaP+bjYPnunbSNidpbCQ=
@@ -91,4 +92,5 @@ google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwl
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hmm_probabilities.go
+++ b/hmm_probabilities.go
@@ -6,23 +6,27 @@ import "math"
 type HmmProbabilities struct {
 	sigma float64
 	beta  float64
+	// precomputed 1/beta (loop-invariant)
+	invBeta float64
+	// precomputed log(1/beta) (loop-invariant)
+	logInvBeta float64
 }
 
 // HmmProbabilitiesDefault Constructor for creating HmmProbabilities with default values
 // Sigma - standard deviation of the normal distribution [m] used for modeling the GPS error
 // Beta - beta parameter of the exponential distribution used for modeling transition probabilities
 func HmmProbabilitiesDefault() *HmmProbabilities {
-	return &HmmProbabilities{
-		sigma: 4.07,
-		beta:  0.00959442,
-	}
+	return NewHmmProbabilities(4.07, 0.00959442)
 }
 
 // NewHmmProbabilities Constructor for creating HmmProbabilities with provided values
 func NewHmmProbabilities(sigma, beta float64) *HmmProbabilities {
+	invBeta := 1.0 / beta
 	return &HmmProbabilities{
-		sigma: sigma,
-		beta:  beta,
+		sigma:      sigma,
+		beta:       beta,
+		invBeta:    invBeta,
+		logInvBeta: math.Log(invBeta),
 	}
 }
 
@@ -51,7 +55,8 @@ func (hp *HmmProbabilities) TransitionLogProbability(routeLength, linearDistance
 	if err != nil {
 		return 0, err
 	}
-	return LogExponentialDistribution(hp.beta, transitionMetric), nil
+	// log(1/beta) - x/beta, with both constants precomputed
+	return hp.logInvBeta - transitionMetric*hp.invBeta, nil
 }
 
 // normalizedTransitionMetric

--- a/isochrones_wrapper.go
+++ b/isochrones_wrapper.go
@@ -47,7 +47,7 @@ func (matcher *MapMatcher) FindIsochrones(source *GPSMeasurement, maxCost float6
 	s2polylineSource := matcher.engine.storage.GetEdge(closestSource[0].EdgeID)
 	// Find vertex for 'source' point
 	m, n := s2polylineSource.Source, s2polylineSource.Target
-	edgeSource := matcher.engine.edges[m][n]
+	edgeSource := matcher.engine.edges.Get(m, n)
 	if edgeSource == nil {
 		return nil, fmt.Errorf("Edge 'source' not found in graph")
 	}

--- a/isochrones_wrapper.go
+++ b/isochrones_wrapper.go
@@ -51,7 +51,7 @@ func (matcher *MapMatcher) FindIsochrones(source *GPSMeasurement, maxCost float6
 	if edgeSource == nil {
 		return nil, fmt.Errorf("Edge 'source' not found in graph")
 	}
-	_, fractionSource, _ := spatial.CalcProjection(*edgeSource.Polyline, source.Point)
+	_, fractionSource, _ := spatial.CalcProjectionCached(edgeSource, source.Point)
 	choosenSourceVertex := n
 	if fractionSource > 0.5 {
 		choosenSourceVertex = m

--- a/map_engine.go
+++ b/map_engine.go
@@ -22,7 +22,7 @@ import (
 // vertexComponent - matches vertex ID to its weakly connected component ID
 // bigComponentID - ID of the largest weakly connected component. -1 if no components found
 type MapEngine struct {
-	edges     map[int64]map[int64]*spatial.Edge
+	edges     *EdgeGraph
 	storage   spatial.Storage
 	vertices  map[int64]*spatial.Vertex
 	graph     ch.Graph
@@ -40,7 +40,7 @@ type MapEngine struct {
 func NewMapEngineDefault() *MapEngine {
 	storage := spatial.NewStorage(spatial.StorageTypeSpherical)
 	return &MapEngine{
-		edges:    make(map[int64]map[int64]*spatial.Edge),
+		edges:    NewEdgeGraph(),
 		vertices: make(map[int64]*spatial.Vertex),
 		storage:  storage,
 	}
@@ -49,7 +49,7 @@ func NewMapEngineDefault() *MapEngine {
 // NewMapEngine Returns pointer to created MapEngine with provided parameters
 func NewMapEngine(opts ...func(*MapEngine)) *MapEngine {
 	engine := &MapEngine{
-		edges:    make(map[int64]map[int64]*spatial.Edge),
+		edges:    NewEdgeGraph(),
 		vertices: make(map[int64]*spatial.Vertex),
 		storage:  nil,
 	}
@@ -94,10 +94,7 @@ func WithS2Storage(storage *spatial.S2Storage) func(*MapEngine) {
 func WithEdges(edges []*spatial.Edge) func(*MapEngine) {
 	return func(engine *MapEngine) {
 		for _, edge := range edges {
-			if engine.edges[edge.Source] == nil {
-				engine.edges[edge.Source] = make(map[int64]*spatial.Edge)
-			}
-			engine.edges[edge.Source][edge.Target] = edge
+			engine.edges.Set(edge.Source, edge.Target, edge)
 			if engine.storage != nil {
 				engine.storage.AddEdge(uint64(edge.ID), edge)
 			}
@@ -145,10 +142,8 @@ func (engine *MapEngine) routeDistanceMeters(path []int64) float64 {
 	for i := 0; i < len(path)-1; i++ {
 		from := path[i]
 		to := path[i+1]
-		if targets, ok := engine.edges[from]; ok {
-			if edge, ok := targets[to]; ok {
-				totalMeters += edge.LengthMeters
-			}
+		if edge := engine.edges.Get(from, to); edge != nil {
+			totalMeters += edge.LengthMeters
 		}
 	}
 	return totalMeters
@@ -156,7 +151,7 @@ func (engine *MapEngine) routeDistanceMeters(path []int64) float64 {
 
 func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcutsFname string) error {
 	// Allocate memory for edges
-	engine.edges = make(map[int64]map[int64]*spatial.Edge)
+	engine.edges = NewEdgeGraph()
 
 	// Read edges first
 	fileEdges, err := os.Open(edgesFname)
@@ -223,9 +218,6 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Can't parse WKT geometry of the edge: from_vertex_id = '%d' | to_vertex_id = '%d' | geom = '%s'", sourceVertex, targetVertex, coordinates))
 		}
-		if _, ok := engine.edges[sourceVertex]; !ok {
-			engine.edges[sourceVertex] = make(map[int64]*spatial.Edge)
-		}
 		lengthMeters := weight // fallback: if no length_meters column, use weight
 		if edgesLookup.Has("length_meters") {
 			lengthMeters, err = edgesLookup.Float64(record, "length_meters")
@@ -241,7 +233,7 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 			LengthMeters: lengthMeters,
 			Polyline:     s2Polyline,
 		}
-		engine.edges[sourceVertex][targetVertex] = &edge
+		engine.edges.Set(sourceVertex, targetVertex, &edge)
 
 		err = engine.storage.AddEdge(uint64(edgeID), &edge)
 		if err != nil {

--- a/map_engine.go
+++ b/map_engine.go
@@ -233,6 +233,8 @@ func (engine *MapEngine) extractDataFromCSVs(edgesFname, verticesFname, shortcut
 			LengthMeters: lengthMeters,
 			Polyline:     s2Polyline,
 		}
+		edge.PrecomputeCumLen()
+		edge.PrecomputeBound()
 		engine.edges.Set(sourceVertex, targetVertex, &edge)
 
 		err = engine.storage.AddEdge(uint64(edgeID), &edge)

--- a/map_matcher.go
+++ b/map_matcher.go
@@ -210,7 +210,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 			s2polyline := matcher.engine.storage.GetEdge(closest[j].EdgeID)
 			m := s2polyline.Source
 			n := s2polyline.Target
-			edge := matcher.engine.edges[m][n]
+			edge := matcher.engine.edges.Get(m, n)
 
 			// Use appropriate projection based on SRID
 			var proj s2.Point

--- a/map_matcher.go
+++ b/map_matcher.go
@@ -513,20 +513,24 @@ func (matcher *MapMatcher) PrepareViterbi(obsStates []*CandidateLayer, routeLeng
 		statesIndx = make(map[int]int)
 		idx := 0
 		for i := range obsStates {
+			layerStates := make([]viterbi.State, len(obsStates[i].States))
 			for j := range obsStates[i].States {
-				v.AddState(obsStates[i].States[j])
+				layerStates[j] = obsStates[i].States[j]
 				statesIndx[obsStates[i].States[j].ID()] = idx
 				fmt.Printf(`CustomState{Name: "%d", id: %d}%s`, obsStates[i].States[j].GraphEdge.ID, obsStates[i].States[j].ID(), ",\n")
 				idx++
 			}
+			v.AddLayer(layerStates)
 			fmt.Println()
 		}
 		fmt.Println()
 	} else {
 		for i := range obsStates {
+			layerStates := make([]viterbi.State, len(obsStates[i].States))
 			for j := range obsStates[i].States {
-				v.AddState(obsStates[i].States[j])
+				layerStates[j] = obsStates[i].States[j]
 			}
+			v.AddLayer(layerStates)
 		}
 	}
 	for i := range gpsMeasurements {

--- a/map_matcher.go
+++ b/map_matcher.go
@@ -220,7 +220,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 
 			if srid == 4326 {
 				// Spherical geometry (WGS84)
-				proj, fraction, next = spatial.CalcProjection(*edge.Polyline, s2point)
+				proj, fraction, next = spatial.CalcProjectionCached(edge, s2point)
 				latLng := s2.LatLngFromPoint(proj)
 				lon = latLng.Lng.Degrees()
 				lat = latLng.Lat.Degrees()
@@ -263,23 +263,38 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 	vertexCache := make(map[[2]int64]cachedRoute)
 
 	// @todo: Consider to use ShortestPathOneToMany (need to deal with the order of writing data to to chRoutes and routeLengths)
+	//
+	// Break-point detection for sub-matches:
+	// For each consecutive pair of layers (i-1, i) we try to build a route between every candidate pair.
+	// If NO candidate pair produces a valid path, we treat layer i as a break point - the preceding part
+	// becomes a finalized Segment (→ its own SubMatch), and a fresh segment starts at layer i.
+	// `anyValidRoute` is the fused, in-loop replacement of the old isBreakPoint() helper: it is set
+	// to true in every branch that writes a non-empty path into chRoutes[key]; if it stays false after
+	// the full M×N scan, we've detected a break point.
 	for i := 1; i < len(layers); i++ {
 		prevStates := layers[i-1]
 		currentStates := layers[i]
+		anyValidRoute := false
 		for m := range prevStates {
 			for n := range currentStates {
 				key := [2]int{prevStates[m].RoadPositionID, currentStates[n].RoadPositionID}
 				if prevStates[m].RoutingGraphVertex == currentStates[n].RoutingGraphVertex {
 					if prevStates[m].GraphEdge.ID == currentStates[n].GraphEdge.ID {
+						// Trivial route on the same edge (same routing vertex, same edge) - never a break into submatches
 						ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
 						chRoutes[key] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
 						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], ans)
+						anyValidRoute = true
 					} else {
 						// We should jump to source vertex of current state, since edges are not the same
 						rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].GraphEdge.Source)
 						routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
 						chRoutes[key] = finalPath
 						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
+						// Only a non-empty CH path counts for break-point detection
+						if len(finalPath) > 0 {
+							anyValidRoute = true
+						}
 					}
 					continue
 				}
@@ -290,6 +305,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 					ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
 					chRoutes[key] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
 					currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], ans)
+					anyValidRoute = true
 					continue
 				}
 				rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].RoutingGraphVertex)
@@ -302,18 +318,22 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 				routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
 				chRoutes[key] = finalPath
 				currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
+				// Only a non-empty CH path counts for break-point detection
+				if len(finalPath) > 0 {
+					anyValidRoute = true
+				}
 			}
 		}
 
-		// Check for break point on-the-fly
-		if isBreakPoint(prevStates, currentStates, chRoutes) {
-			// Finalize current segment with its routeLengths
+		// Break point (submatches): the entire M×N scan produced no valid route - the trace must be split here.
+		// Finalize the current sub-match [segmentStart .. i-1] and restart with fresh routeLengths at i.
+		// Each Segment later becomes an independent SubMatch in MatcherResult.SubMatches.
+		if !anyValidRoute {
 			segments = append(segments, Segment{
 				start:        segmentStart,
 				end:          i - 1,
 				routeLengths: currentRouteLengths,
 			})
-			// Start new segment with fresh routeLengths
 			segmentStart = i
 			currentRouteLengths = make(lengths)
 		}
@@ -487,23 +507,27 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 func (matcher *MapMatcher) PrepareViterbi(obsStates []*CandidateLayer, routeLengths lengths, gpsMeasurements []*GPSMeasurement) (*viterbi.Viterbi, error) {
 	v := viterbi.New()
 
-	statesIndx := make(map[int]int)
-	idx := 0
-	for i := range obsStates {
-		for j := range obsStates[i].States {
-			v.AddState(obsStates[i].States[j])
-			statesIndx[obsStates[i].States[j].ID()] = idx
-			if ViterbiDebug {
+	// statesIndx is used only for human-readable debug output; skip populating in release mode
+	var statesIndx map[int]int
+	if ViterbiDebug {
+		statesIndx = make(map[int]int)
+		idx := 0
+		for i := range obsStates {
+			for j := range obsStates[i].States {
+				v.AddState(obsStates[i].States[j])
+				statesIndx[obsStates[i].States[j].ID()] = idx
 				fmt.Printf(`CustomState{Name: "%d", id: %d}%s`, obsStates[i].States[j].GraphEdge.ID, obsStates[i].States[j].ID(), ",\n")
+				idx++
 			}
-			idx++
-		}
-		if ViterbiDebug {
 			fmt.Println()
 		}
-	}
-	if ViterbiDebug {
 		fmt.Println()
+	} else {
+		for i := range obsStates {
+			for j := range obsStates[i].States {
+				v.AddState(obsStates[i].States[j])
+			}
+		}
 	}
 	for i := range gpsMeasurements {
 		if ViterbiDebug {
@@ -583,9 +607,17 @@ func (matcher *MapMatcher) computeEmissionLogProbabilities(layer *CandidateLayer
 		sigma = layer.Observation.accuracy
 	}
 
+	// Loop-invariant: log(1/(sigma*sqrt(2*pi))) and 1/sigma precomputed once per layer
+	logConst := math.Log(1.0 / (sqrtTwoPi * sigma))
+	invSigma := 1.0 / sigma
+	// Pre-allocate to exact size to avoid append-growth copies
+	if cap(layer.EmissionLogProbabilities) < len(layer.States) {
+		layer.EmissionLogProbabilities = make([]emission, 0, len(layer.States))
+	}
 	for i := range layer.States {
 		distance := layer.States[i].Projected.DistanceTo(layer.Observation.GeoPoint)
-		emissionLogProb := LogNormalDistribution(sigma, distance)
+		xOverSigma := distance * invSigma
+		emissionLogProb := logConst - 0.5*xOverSigma*xOverSigma
 		layer.AddEmissionProbability(layer.States[i], emissionLogProb)
 	}
 }
@@ -598,6 +630,11 @@ func (matcher *MapMatcher) computeEmissionLogProbabilities(layer *CandidateLayer
 func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentLayer *CandidateLayer, routeLengths lengths) error {
 	straightDistance := prevLayer.Observation.GeoPoint.DistanceTo(currentLayer.Observation.GeoPoint)
 	timeDiff := currentLayer.Observation.dateTime.Sub(prevLayer.Observation.dateTime).Seconds()
+	// Pre-allocate to worst-case K*K size to avoid append-growth copies
+	maxPairs := len(prevLayer.States) * len(currentLayer.States)
+	if cap(currentLayer.TransitionLogProbabilities) < maxPairs {
+		currentLayer.TransitionLogProbabilities = make([]transition, 0, maxPairs)
+	}
 	for i := range prevLayer.States {
 		from := prevLayer.States[i]
 		for j := range currentLayer.States {
@@ -619,21 +656,6 @@ func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentL
 		}
 	}
 	return nil
-}
-
-// isBreakPoint checks if there are no valid routes between two consecutive layers
-func isBreakPoint(prevStates, currentStates RoadPositions, chRoutes map[[2]int][]int64) bool {
-	for m := range prevStates {
-		fromID := prevStates[m].RoadPositionID
-		for n := range currentStates {
-			toID := currentStates[n].RoadPositionID
-			path, ok := chRoutes[[2]int{fromID, toID}]
-			if ok && len(path) > 0 {
-				return false // Found valid route
-			}
-		}
-	}
-	return true // No valid routes found
 }
 
 // getCachedPath is a helper function to get or compute shortest path with caching

--- a/map_matcher.go
+++ b/map_matcher.go
@@ -252,35 +252,33 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 		layers = append(layers, localStates)
 		obsState[i] = NewCandidateLayer(engineGpsMeasurements[i], localStates)
 	}
-	chRoutes := make(map[int]map[int][]int64)
+	chRoutes := make(map[[2]int][]int64)
 
 	segments := []Segment{}
 	segmentStart := 0
 	currentRouteLengths := make(lengths)
 
 	// vertex-level path cache to avoid recomputing same routes
-	// key: fromVertex -> toVertex -> {rawCost, rawPath}
-	vertexCache := make(map[int64]map[int64]cachedRoute)
+	// key: [fromVertex, toVertex] -> {rawCost, rawPath}
+	vertexCache := make(map[[2]int64]cachedRoute)
 
 	// @todo: Consider to use ShortestPathOneToMany (need to deal with the order of writing data to to chRoutes and routeLengths)
 	for i := 1; i < len(layers); i++ {
 		prevStates := layers[i-1]
 		currentStates := layers[i]
 		for m := range prevStates {
-			if _, ok := chRoutes[prevStates[m].RoadPositionID]; !ok {
-				chRoutes[prevStates[m].RoadPositionID] = make(map[int][]int64)
-			}
 			for n := range currentStates {
+				key := [2]int{prevStates[m].RoadPositionID, currentStates[n].RoadPositionID}
 				if prevStates[m].RoutingGraphVertex == currentStates[n].RoutingGraphVertex {
 					if prevStates[m].GraphEdge.ID == currentStates[n].GraphEdge.ID {
 						ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
-						chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
+						chRoutes[key] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
 						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], ans)
 					} else {
 						// We should jump to source vertex of current state, since edges are not the same
 						rawCost, rawPath := getCachedPath(matcher.engine.queryPool, vertexCache, matcher.engine.vertexStrongComponent, prevStates[m].RoutingGraphVertex, currentStates[n].GraphEdge.Source)
 						routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
-						chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
+						chRoutes[key] = finalPath
 						currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 					}
 					continue
@@ -290,7 +288,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 				// If moving backward, the edge is likely a reverse-direction candidate => fall through to CH routing.
 				if prevStates[m].GraphEdge.ID == currentStates[n].GraphEdge.ID && prevStates[m].beforeProjection <= currentStates[n].beforeProjection {
 					ans := prevStates[m].Projected.DistanceTo(currentStates[n].Projected)
-					chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
+					chRoutes[key] = []int64{prevStates[m].GraphEdge.Source, prevStates[m].GraphEdge.Target}
 					currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], ans)
 					continue
 				}
@@ -302,7 +300,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 				// @todo: this could lead to negative values. Need to investigate when it happens
 				// finalCost = (finalCost + prevStates[m].afterProjection) - currentStates[n].afterProjection
 				routeDistMeters, finalPath := matcher.resolveRoute(rawCost, rawPath, currentStates[n].GraphEdge.Target)
-				chRoutes[prevStates[m].RoadPositionID][currentStates[n].RoadPositionID] = finalPath
+				chRoutes[key] = finalPath
 				currentRouteLengths.AddRouteLength(prevStates[m], currentStates[n], routeDistMeters)
 			}
 		}
@@ -486,7 +484,7 @@ func (matcher *MapMatcher) Run(gpsMeasurements []*GPSMeasurement, statesRadiusMe
 	states - set of States
 	gpsMeasurements - set of Observations
 */
-func (matcher *MapMatcher) PrepareViterbi(obsStates []*CandidateLayer, routeLengths map[int]map[int]float64, gpsMeasurements []*GPSMeasurement) (*viterbi.Viterbi, error) {
+func (matcher *MapMatcher) PrepareViterbi(obsStates []*CandidateLayer, routeLengths lengths, gpsMeasurements []*GPSMeasurement) (*viterbi.Viterbi, error) {
 	v := viterbi.New()
 
 	statesIndx := make(map[int]int)
@@ -597,22 +595,22 @@ func (matcher *MapMatcher) computeEmissionLogProbabilities(layer *CandidateLayer
 	prevLayer - previous Observation
 	currentLayer - current Observation
 */
-func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentLayer *CandidateLayer, routeLengths map[int]map[int]float64) error {
+func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentLayer *CandidateLayer, routeLengths lengths) error {
 	straightDistance := prevLayer.Observation.GeoPoint.DistanceTo(currentLayer.Observation.GeoPoint)
 	timeDiff := currentLayer.Observation.dateTime.Sub(prevLayer.Observation.dateTime).Seconds()
 	for i := range prevLayer.States {
 		from := prevLayer.States[i]
 		for j := range currentLayer.States {
 			to := currentLayer.States[j]
-			if routeLengths[from.RoadPositionID][to.RoadPositionID] < 0 {
+			rl := routeLengths[[2]int{from.RoadPositionID, to.RoadPositionID}]
+			if rl < 0 {
 				continue
 			}
-			if routeLengths[from.RoadPositionID][to.RoadPositionID] > ROUTE_LENGTH_THRESHOLD {
+			if rl > ROUTE_LENGTH_THRESHOLD {
 				// Restrict max route length assuming that too large length is just bad
 				currentLayer.AddTransitionProbability(from, to, -ROUTE_LENGTH_THRESHOLD)
 				continue
 			}
-			rl := routeLengths[from.RoadPositionID][to.RoadPositionID]
 			transitionLogProbability, err := matcher.hmmParams.TransitionLogProbability(rl, straightDistance, timeDiff)
 			if err != nil {
 				return err
@@ -624,15 +622,12 @@ func (matcher *MapMatcher) computeTransitionLogProbabilities(prevLayer, currentL
 }
 
 // isBreakPoint checks if there are no valid routes between two consecutive layers
-func isBreakPoint(prevStates, currentStates RoadPositions, chRoutes map[int]map[int][]int64) bool {
+func isBreakPoint(prevStates, currentStates RoadPositions, chRoutes map[[2]int][]int64) bool {
 	for m := range prevStates {
 		fromID := prevStates[m].RoadPositionID
-		if _, ok := chRoutes[fromID]; !ok {
-			continue
-		}
 		for n := range currentStates {
 			toID := currentStates[n].RoadPositionID
-			path, ok := chRoutes[fromID][toID]
+			path, ok := chRoutes[[2]int{fromID, toID}]
 			if ok && len(path) > 0 {
 				return false // Found valid route
 			}
@@ -643,7 +638,7 @@ func isBreakPoint(prevStates, currentStates RoadPositions, chRoutes map[int]map[
 
 // getCachedPath is a helper function to get or compute shortest path with caching
 // It uses SCC (Strongly Connected Components) to quickly reject impossible routes
-func getCachedPath(queryPool *ch.QueryPool, vertexCache map[int64]map[int64]cachedRoute, vertexSCC map[int64]int64, fromVertex, toVertex int64) (float64, []int64) {
+func getCachedPath(queryPool *ch.QueryPool, vertexCache map[[2]int64]cachedRoute, vertexSCC map[int64]int64, fromVertex, toVertex int64) (float64, []int64) {
 	// SCC check: if vertices are in different SCCs, no path exists
 	fromSCC, fromOK := vertexSCC[fromVertex]
 	toSCC, toOK := vertexSCC[toVertex]
@@ -652,18 +647,14 @@ func getCachedPath(queryPool *ch.QueryPool, vertexCache map[int64]map[int64]cach
 		return -1, nil
 	}
 
+	key := [2]int64{fromVertex, toVertex}
 	// Check cache first
-	if inner, ok := vertexCache[fromVertex]; ok {
-		if cached, ok := inner[toVertex]; ok {
-			return cached.cost, cached.path
-		}
+	if cached, ok := vertexCache[key]; ok {
+		return cached.cost, cached.path
 	}
 	// Compute and cache using thread-safe query pool
 	rawCost, rawPath := queryPool.ShortestPath(fromVertex, toVertex)
-	if vertexCache[fromVertex] == nil {
-		vertexCache[fromVertex] = make(map[int64]cachedRoute)
-	}
-	vertexCache[fromVertex][toVertex] = cachedRoute{cost: rawCost, path: rawPath}
+	vertexCache[key] = cachedRoute{cost: rawCost, path: rawPath}
 	return rawCost, rawPath
 }
 

--- a/map_matcher_4326_average_test.go
+++ b/map_matcher_4326_average_test.go
@@ -53,16 +53,16 @@ func TestMapMatcher_4326BIG(t *testing.T) {
 		t.Error(err)
 	}
 
-	correctStates.SubMatches[0].Observations[0].MatchedEdge = *matcher.engine.edges[13640][13641]
-	correctStates.SubMatches[0].Observations[1].MatchedEdge = *matcher.engine.edges[13650][13651]
-	correctStates.SubMatches[0].Observations[2].MatchedEdge = *matcher.engine.edges[13659][13660]
-	correctStates.SubMatches[0].Observations[3].MatchedEdge = *matcher.engine.edges[13661][13662]
-	correctStates.SubMatches[0].Observations[4].MatchedEdge = *matcher.engine.edges[13663][13664]
-	correctStates.SubMatches[0].Observations[5].MatchedEdge = *matcher.engine.edges[13664][13665]
-	correctStates.SubMatches[0].Observations[6].MatchedEdge = *matcher.engine.edges[13665][13666]
-	correctStates.SubMatches[0].Observations[7].MatchedEdge = *matcher.engine.edges[16784][16785]
-	correctStates.SubMatches[0].Observations[8].MatchedEdge = *matcher.engine.edges[16788][16789]
-	correctStates.SubMatches[0].Observations[9].MatchedEdge = *matcher.engine.edges[32639][32640]
+	correctStates.SubMatches[0].Observations[0].MatchedEdge = *matcher.engine.edges.Get(13640, 13641)
+	correctStates.SubMatches[0].Observations[1].MatchedEdge = *matcher.engine.edges.Get(13650, 13651)
+	correctStates.SubMatches[0].Observations[2].MatchedEdge = *matcher.engine.edges.Get(13659, 13660)
+	correctStates.SubMatches[0].Observations[3].MatchedEdge = *matcher.engine.edges.Get(13661, 13662)
+	correctStates.SubMatches[0].Observations[4].MatchedEdge = *matcher.engine.edges.Get(13663, 13664)
+	correctStates.SubMatches[0].Observations[5].MatchedEdge = *matcher.engine.edges.Get(13664, 13665)
+	correctStates.SubMatches[0].Observations[6].MatchedEdge = *matcher.engine.edges.Get(13665, 13666)
+	correctStates.SubMatches[0].Observations[7].MatchedEdge = *matcher.engine.edges.Get(16784, 16785)
+	correctStates.SubMatches[0].Observations[8].MatchedEdge = *matcher.engine.edges.Get(16788, 16789)
+	correctStates.SubMatches[0].Observations[9].MatchedEdge = *matcher.engine.edges.Get(32639, 32640)
 
 	statesRadiusMeters := -1.0
 	maxStates := 5

--- a/map_matcher_4326_small_test.go
+++ b/map_matcher_4326_small_test.go
@@ -77,11 +77,13 @@ func TestMapMatcherSRID_4326(t *testing.T) {
 		}
 
 		for i := range resultSubMatch.Observations {
-			if resultSubMatch.Observations[i].MatchedEdge != correctSubMatch.Observations[i].MatchedEdge {
+			gotEdge := resultSubMatch.Observations[i].MatchedEdge
+			wantEdge := correctSubMatch.Observations[i].MatchedEdge
+			if gotEdge.Source != wantEdge.Source || gotEdge.Target != wantEdge.Target || gotEdge.ID != wantEdge.ID {
 				t.Errorf("SubMatch %d, observation %d: matched edge should be %d->%d, but got %d->%d",
 					s, resultSubMatch.Observations[i].Observation.id,
-					correctSubMatch.Observations[i].MatchedEdge.Source, correctSubMatch.Observations[i].MatchedEdge.Target,
-					resultSubMatch.Observations[i].MatchedEdge.Source, resultSubMatch.Observations[i].MatchedEdge.Target,
+					wantEdge.Source, wantEdge.Target,
+					gotEdge.Source, gotEdge.Target,
 				)
 			}
 		}

--- a/map_matcher_4326_small_test.go
+++ b/map_matcher_4326_small_test.go
@@ -42,10 +42,10 @@ func TestMapMatcherSRID_4326(t *testing.T) {
 		t.Error(err)
 	}
 
-	correctStates.SubMatches[0].Observations[0].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[0].Observations[1].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[0].Observations[2].MatchedEdge = *matcher.engine.edges[101][102]
-	correctStates.SubMatches[0].Observations[3].MatchedEdge = *matcher.engine.edges[102][105]
+	correctStates.SubMatches[0].Observations[0].MatchedEdge = *matcher.engine.edges.Get(101, 102)
+	correctStates.SubMatches[0].Observations[1].MatchedEdge = *matcher.engine.edges.Get(101, 102)
+	correctStates.SubMatches[0].Observations[2].MatchedEdge = *matcher.engine.edges.Get(101, 102)
+	correctStates.SubMatches[0].Observations[3].MatchedEdge = *matcher.engine.edges.Get(102, 105)
 
 	statesRadiusMeters := 7.0
 	maxStates := 5

--- a/map_matcher_result.go
+++ b/map_matcher_result.go
@@ -106,7 +106,7 @@ func (matcher *MapMatcher) prepareSubMatch(vpath viterbi.ViterbiPath, gpsMeasure
 		for j := 1; j < len(path); j++ {
 			sourceVertex := path[j-1]
 			targetVertex := path[j]
-			edge := matcher.engine.edges[sourceVertex][targetVertex]
+			edge := matcher.engine.edges.Get(sourceVertex, targetVertex)
 			if len(*edge.Polyline) < 2 {
 				fmt.Printf("[WARNING]: Edge %d have less than 2 points\n", edge.ID)
 			}

--- a/map_matcher_result.go
+++ b/map_matcher_result.go
@@ -55,7 +55,7 @@ type MatcherResult struct {
 }
 
 // prepareSubMatch returns SubMatch for corresponding ViterbiPath, set of gps measurements and calculated routes' lengths
-func (matcher *MapMatcher) prepareSubMatch(vpath viterbi.ViterbiPath, gpsMeasurements GPSMeasurements, layers []RoadPositions, chRoutes map[int]map[int][]int64) SubMatch {
+func (matcher *MapMatcher) prepareSubMatch(vpath viterbi.ViterbiPath, gpsMeasurements GPSMeasurements, layers []RoadPositions, chRoutes map[[2]int][]int64) SubMatch {
 	subMatch := SubMatch{
 		Observations: make([]ObservationResult, len(gpsMeasurements)),
 		Probability:  vpath.Probability,
@@ -99,7 +99,7 @@ func (matcher *MapMatcher) prepareSubMatch(vpath viterbi.ViterbiPath, gpsMeasure
 		if previousState.GraphEdge.ID == currentState.GraphEdge.ID {
 			continue
 		}
-		path := chRoutes[previousState.RoadPositionID][currentState.RoadPositionID]
+		path := chRoutes[[2]int{previousState.RoadPositionID, currentState.RoadPositionID}]
 		if len(path) < 2 {
 			continue
 		}

--- a/map_matcher_result.go
+++ b/map_matcher_result.go
@@ -114,10 +114,9 @@ func (matcher *MapMatcher) prepareSubMatch(vpath viterbi.ViterbiPath, gpsMeasure
 				continue
 			}
 			lastEdgeID = edge.ID
-			edgeGeomCopy := make(s2.Polyline, len(*edge.Polyline))
-			copy(edgeGeomCopy, *edge.Polyline)
+			// Zero-copy: engine's polyline is immutable after load; caller must treat Geom as read-only.
 			subMatch.Observations[i-1].NextEdges = append(subMatch.Observations[i-1].NextEdges, EdgeResult{
-				Geom:   edgeGeomCopy,
+				Geom:   *edge.Polyline,
 				Weight: edge.Weight,
 				ID:     edge.ID,
 			})

--- a/map_matcher_simple_sp.go
+++ b/map_matcher_simple_sp.go
@@ -76,7 +76,7 @@ func (matcher *MapMatcher) FindShortestPath(source, target *GPSMeasurement, stat
 	for i := 1; i < len(path); i++ {
 		s := path[i-1]
 		t := path[i]
-		edge := matcher.engine.edges[s][t]
+		edge := matcher.engine.edges.Get(s, t)
 		edges = append(edges, *edge)
 		edgeGeomCopy := make(s2.Polyline, len(*edge.Polyline))
 		copy(edgeGeomCopy, *edge.Polyline)
@@ -127,7 +127,7 @@ func (matcher *MapMatcher) getCandidates(pt s2.Point, radiusMeters float64, limi
 		}
 
 		m, n := edgeData.Source, edgeData.Target
-		edge := matcher.engine.edges[m][n]
+		edge := matcher.engine.edges.Get(m, n)
 		if edge == nil {
 			continue
 		}

--- a/map_matcher_simple_sp.go
+++ b/map_matcher_simple_sp.go
@@ -78,10 +78,9 @@ func (matcher *MapMatcher) FindShortestPath(source, target *GPSMeasurement, stat
 		t := path[i]
 		edge := matcher.engine.edges.Get(s, t)
 		edges = append(edges, *edge)
-		edgeGeomCopy := make(s2.Polyline, len(*edge.Polyline))
-		copy(edgeGeomCopy, *edge.Polyline)
+		// Zero-copy: engine's polyline is immutable after load; caller must treat Geom as read-only.
 		intermediateEdges = append(intermediateEdges, EdgeResult{
-			Geom:   edgeGeomCopy,
+			Geom:   *edge.Polyline,
 			Weight: edge.Weight,
 			ID:     edge.ID,
 		})
@@ -133,7 +132,7 @@ func (matcher *MapMatcher) getCandidates(pt s2.Point, radiusMeters float64, limi
 		}
 
 		// Determine which vertex to use based on projection fraction
-		_, fraction, _ := spatial.CalcProjection(*edge.Polyline, pt)
+		_, fraction, _ := spatial.CalcProjectionCached(edge, pt)
 		vertex := n
 		if fraction > 0.5 {
 			vertex = m

--- a/map_matcher_submatch_test.go
+++ b/map_matcher_submatch_test.go
@@ -202,28 +202,28 @@ func TestMapMatcherSubMatches(t *testing.T) {
 		SubMatches: []SubMatch{
 			{
 				Observations: []ObservationResult{
-					{Observation: gpsMeasurements[0], MatchedEdge: *mapEngine.edges[0][1]},
-					{Observation: gpsMeasurements[1], MatchedEdge: *mapEngine.edges[2][3]},
+					{Observation: gpsMeasurements[0], MatchedEdge: *mapEngine.edges.Get(0, 1)},
+					{Observation: gpsMeasurements[1], MatchedEdge: *mapEngine.edges.Get(2, 3)},
 				},
 				Probability: -791.677435,
 			},
 			{
 				Observations: []ObservationResult{
-					{Observation: gpsMeasurements[2], MatchedEdge: *mapEngine.edges[5][6]},
+					{Observation: gpsMeasurements[2], MatchedEdge: *mapEngine.edges.Get(5, 6)},
 				},
 				Probability: -954.672372,
 			},
 			{
 				Observations: []ObservationResult{
-					{Observation: gpsMeasurements[3], MatchedEdge: *mapEngine.edges[8][9]},
-					{Observation: gpsMeasurements[4], MatchedEdge: *mapEngine.edges[9][10]},
-					{Observation: gpsMeasurements[5], MatchedEdge: *mapEngine.edges[10][11]},
+					{Observation: gpsMeasurements[3], MatchedEdge: *mapEngine.edges.Get(8, 9)},
+					{Observation: gpsMeasurements[4], MatchedEdge: *mapEngine.edges.Get(9, 10)},
+					{Observation: gpsMeasurements[5], MatchedEdge: *mapEngine.edges.Get(10, 11)},
 				},
 				Probability: -8100.966270,
 			},
 			{
 				Observations: []ObservationResult{
-					{Observation: gpsMeasurements[6], MatchedEdge: *mapEngine.edges[13][14]},
+					{Observation: gpsMeasurements[6], MatchedEdge: *mapEngine.edges.Get(13, 14)},
 				},
 				Probability: -196.691325,
 			},

--- a/routing_benchmark_test.go
+++ b/routing_benchmark_test.go
@@ -155,7 +155,7 @@ func TestRouting_SingleRun(t *testing.T) {
 		t.Fatalf("Failed to load graph: %v", err)
 	}
 	t.Logf("Graph loaded in %v", time.Since(loadStart))
-	t.Logf("Vertices: %d, Edges: %d", len(matcher.engine.vertexStrongComponent), len(matcher.engine.edges))
+	t.Logf("Vertices: %d, Edges: %d", len(matcher.engine.vertexStrongComponent), matcher.engine.edges.Len())
 
 	source := NewGPSMeasurement(1, benchStartLon, benchStartLat, 4326, WithGPSTime(time.Now()))
 	target := NewGPSMeasurement(2, benchEndLon, benchEndLat, 4326, WithGPSTime(time.Now()))

--- a/spatial/edge.go
+++ b/spatial/edge.go
@@ -1,6 +1,7 @@
 package spatial
 
 import (
+	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 )
 
@@ -11,12 +12,52 @@ import (
 	Target - identifier of target vertex
 	Weight - cost of moving on edge (usually it is length or time)
 	Polyline - geometry of edge, pointer to s2.Polyline (wrapper)
+	CumSegLen - cumulative spherical segment distances (radians), precomputed; len == len(*Polyline)-1
+	BoundCenter/BoundRadius - precomputed spherical bounding cap for cheap pruning in spatial queries
 */
 type Edge struct {
 	*s2.Polyline
+	CumSegLen    []float64
+	BoundCenter  s2.Point
+	BoundRadius  s1.Angle
 	Weight       float64
 	LengthMeters float64
 	ID           int64
 	Source       int64
 	Target       int64
+}
+
+// PrecomputeCumLen fills the CumSegLen cache using spherical segment distances.
+// Safe to call once at edge construction time; subsequent calls overwrite the cache.
+// Caller must ensure Polyline has at least 2 points.
+func (e *Edge) PrecomputeCumLen() {
+	if e.Polyline == nil {
+		return
+	}
+	pl := *e.Polyline
+	if len(pl) < 2 {
+		return
+	}
+	cum := make([]float64, len(pl)-1)
+	var accum float64
+	for i := 0; i < len(pl)-1; i++ {
+		accum += float64(pl[i].Distance(pl[i+1]))
+		cum[i] = accum
+	}
+	e.CumSegLen = cum
+}
+
+// PrecomputeBound fills BoundCenter/BoundRadius with the polyline's spherical
+// cap bound. Used to cheaply prune spatial queries without scanning polyline segments.
+func (e *Edge) PrecomputeBound() {
+	if e.Polyline == nil {
+		return
+	}
+	pl := *e.Polyline
+	if len(pl) == 0 {
+		return
+	}
+	cap := e.Polyline.CapBound()
+	e.BoundCenter = cap.Center()
+	e.BoundRadius = cap.Radius()
 }

--- a/spatial/storage_spherical.go
+++ b/spatial/storage_spherical.go
@@ -128,11 +128,23 @@ func (storage *S2Storage) SearchInRadius(pt s2.Point, radius float64) (map[uint6
 	rc := s2.RegionCoverer{MaxLevel: storage.storageLevel, MinLevel: storage.storageLevel}
 	cu := rc.Covering(cap)
 	result := make(map[uint64]float64)
+	radiusAngle := s1.Angle(centerAngle)
 	for _, cellID := range cu {
 		item := storage.BTree.Get(indexedItem{CellID: cellID})
 		if item != nil {
 			for _, edgeID := range item.(indexedItem).edgesInCell {
+				if _, exists := result[edgeID]; exists {
+					continue
+				}
 				polyline := storage.edges[edgeID]
+				// Bounding-cap prune: if the polyline's cap is entirely outside
+				// the search radius, skip the per-segment scan.
+				if polyline.BoundRadius > 0 {
+					chord := s2.ChordAngleBetweenPoints(pt, polyline.BoundCenter)
+					if chord.Angle()-polyline.BoundRadius > radiusAngle {
+						continue
+					}
+				}
 				minDist := s1.ChordAngle(0)
 				for i := 0; i < polyline.Polyline.NumEdges(); i++ {
 					edge := polyline.Polyline.Edge(i)
@@ -205,7 +217,7 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 
 	// Bounded top-n tracker: keeps up to n smallest distances.
 	// topDists[topMaxIdx] is the n-th smallest (the largest among top-n).
-	// No interface boxing — O(n) insert, O(1) peek. n is small (typically 5-10).
+	// No interface boxing, which means O(n) insert, O(1) peek. n is small (typically 5-10).
 	topDists := make([]float64, 0, n)
 	topMaxIdx := 0
 
@@ -231,6 +243,17 @@ func (storage *S2Storage) FindNearest(pt s2.Point, n int) ([]NearestObject, erro
 				polyline := storage.edges[edgeID]
 				if polyline == nil || polyline.Polyline == nil {
 					continue
+				}
+
+				// Bounding-cap prune: when we have n candidates, skip polylines
+				// whose spherical cap lower-bounds the true distance above topMax.
+				// Only apply when the precomputed bound is available.
+				if len(topDists) == n && polyline.BoundRadius > 0 {
+					chord := s2.ChordAngleBetweenPoints(pt, polyline.BoundCenter)
+					lbMeters := (chord.Angle() - polyline.BoundRadius).Radians() * EarthRadius
+					if lbMeters > topDists[topMaxIdx] {
+						continue
+					}
 				}
 
 				// Calculate minimum distance to edge

--- a/spatial/utils.go
+++ b/spatial/utils.go
@@ -33,6 +33,29 @@ func CalcProjection(line s2.Polyline, point s2.Point) (projected s2.Point, fract
 	return pr, (lengthToProj / line.Length()).Radians(), next
 }
 
+// CalcProjectionCached Returns projection on edge's polyline and fraction for point (spherical geometry).
+// Uses precomputed Edge.CumSegLen to avoid O(P) partial-sum and line.Length() rescans.
+// Falls back to CalcProjection when CumSegLen is not populated.
+func CalcProjectionCached(edge *Edge, point s2.Point) (projected s2.Point, fraction float64, next int) {
+	line := *edge.Polyline
+	if len(edge.CumSegLen) == 0 {
+		return CalcProjection(line, point)
+	}
+	pr, next := line.Project(point)
+	var lengthToProj float64
+	if next >= 2 {
+		lengthToProj = edge.CumSegLen[next-2]
+	}
+	if next > 0 {
+		lengthToProj += float64(line[next-1].Distance(pr))
+	}
+	totalLen := edge.CumSegLen[len(edge.CumSegLen)-1]
+	if totalLen == 0 {
+		return pr, 0, next
+	}
+	return pr, lengthToProj / totalLen, next
+}
+
 // CalcProjectionEuclidean Returns projection on line and fraction for point (Euclidean/planar geometry)
 /*
 	line - s2.Polyline (using Vector.X/Y as Euclidean coordinates)

--- a/strong_components.go
+++ b/strong_components.go
@@ -71,7 +71,8 @@ func (engine *MapEngine) strongConnect(v int64, state *tarjanState) {
 	state.onStack[v] = true
 
 	// Consider successors of v (only outgoing edges for SCC)
-	for neighbor := range engine.edges[v] {
+	for _, entry := range engine.edges.Neighbors(v) {
+		neighbor := entry.Target
 		if _, visited := state.indexMap[neighbor]; !visited {
 			// Successor has not yet been visited; recurse on it
 			engine.strongConnect(neighbor, state)
@@ -110,10 +111,10 @@ func (engine *MapEngine) computeStrongConnectedComponents() StrongComponentsResu
 
 	// Collect all vertices
 	vertices := make(map[int64]bool)
-	for src, targets := range engine.edges {
+	for src, entries := range engine.edges.Adj() {
 		vertices[src] = true
-		for dst := range targets {
-			vertices[dst] = true
+		for _, entry := range entries {
+			vertices[entry.Target] = true
 		}
 	}
 

--- a/strong_components_test.go
+++ b/strong_components_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestTarjanSCC_SimpleChain(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create a simple chain: 1 -> 2 -> 3
 	// Each vertex is its own SCC (no cycles)
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{3: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 3, &spatial.Edge{})
 
 	result := engine.computeStrongConnectedComponents()
 
@@ -42,14 +42,14 @@ func TestTarjanSCC_SimpleChain(t *testing.T) {
 
 func TestTarjanSCC_SimpleCycle(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create a cycle: 1 -> 2 -> 3 -> 1
 	// All vertices should be in one SCC
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{3: {}}
-	engine.edges[3] = map[int64]*spatial.Edge{1: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 3, &spatial.Edge{})
+	engine.edges.Set(3, 1, &spatial.Edge{})
 
 	result := engine.computeStrongConnectedComponents()
 
@@ -75,16 +75,16 @@ func TestTarjanSCC_SimpleCycle(t *testing.T) {
 
 func TestTarjanSCC_TwoSeparateCycles(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create two separate cycles:
 	// Cycle 1: 1 -> 2 -> 1
 	// Cycle 2: 3 -> 4 -> 3
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{1: {}}
-	engine.edges[3] = map[int64]*spatial.Edge{4: {}}
-	engine.edges[4] = map[int64]*spatial.Edge{3: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 1, &spatial.Edge{})
+	engine.edges.Set(3, 4, &spatial.Edge{})
+	engine.edges.Set(4, 3, &spatial.Edge{})
 
 	result := engine.computeStrongConnectedComponents()
 
@@ -111,14 +111,14 @@ func TestTarjanSCC_TwoSeparateCycles(t *testing.T) {
 
 func TestTarjanSCC_CycleWithTail(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create: 1 -> 2 -> 3 -> 2 (cycle 2-3) with entry from 1
 	// Vertex 1 is separate, vertices 2,3 form an SCC
-	engine.edges[1] = map[int64]*spatial.Edge{2: {}}
-	engine.edges[2] = map[int64]*spatial.Edge{3: {}}
-	engine.edges[3] = map[int64]*spatial.Edge{2: {}}
+	engine.edges.Set(1, 2, &spatial.Edge{})
+	engine.edges.Set(2, 3, &spatial.Edge{})
+	engine.edges.Set(3, 2, &spatial.Edge{})
 
 	result := engine.computeStrongConnectedComponents()
 
@@ -140,7 +140,7 @@ func TestTarjanSCC_CycleWithTail(t *testing.T) {
 
 func TestTarjanSCC_BigComponent(t *testing.T) {
 	engine := &MapEngine{
-		edges: make(map[int64]map[int64]*spatial.Edge),
+		edges: NewEdgeGraph(),
 	}
 
 	// Create a large cycle (size > SMALL_COMPONENT_SIZE would not be that small)
@@ -150,10 +150,7 @@ func TestTarjanSCC_BigComponent(t *testing.T) {
 		if next > 5 {
 			next = 1
 		}
-		if engine.edges[i] == nil {
-			engine.edges[i] = make(map[int64]*spatial.Edge)
-		}
-		engine.edges[i][next] = &spatial.Edge{}
+		engine.edges.Set(i, next, &spatial.Edge{})
 	}
 
 	result := engine.computeStrongConnectedComponents()


### PR DESCRIPTION
The core edge storage `map[int64]map[int64]*spatial.Edge` uses nested maps: an outer map keyed by source vertex, each value being another map keyed by target vertex. Every edge access (`edges[src][dst]`) requires two hash lookups and traverses two separate hash table structures. On a 40k-vertex graph this creates ~40k inner map objects, each carrying ~120 bytes of runtime overhead (header, bucket pointers, overflow chains) - totaling ~4.8MB of pure bookkeeping with no user data.

what this affects? basically:
- hot path (map matching, routing): double hash lookup on every edge access
- GC pressure: 40k+ small map objects in heap that the garbage collector must scan every cycle
- initial startup (SCC, WCC): map iteration is slower than slice iteration due to random bucket traversal order

For city-scale graphs (500k+ vertices) cases these costs scale linearly, making the nested map layout a bottleneck for both latency and memory.

Once I started touching the edge storage, the same `map[K1]map[K2]V` pattern kept popping up across the Viterbi / CH-prep code. So this PR is bigger than just the edge graph - it's a full pass over the double-hash hot paths plus a few adjacent allocations that showed up in pprof.

Here is summary (what changed, roughly in order of impact):

1. EdgeGraph replaces `map[int64]map[int64]*spatial.Edge`
   - flat `map[[2]int64]*Edge` for O(1) point lookup
   - `map[int64][]EdgeEntry` for neighbor iteration (SCC/WCC)
   - eliminates ~40k inner map allocations
   - single hash lookup in the hot path instead of two

2. Viterbi-prep nested maps flattened (same trick, different maps)
   - `routeLengths map[int]map[int]float64` => flat `map[[2]int]float64` (`lengths` type)
   - `vertexCache map[int64]map[int64]cachedRoute` => flat `map[[2]int64]cachedRoute`
   - `chRoutes map[int]map[int][]int64` => flat `map[[2]int][]int64`
   - all downstream call sites were mechanical replacements

3. Precomputed per-edge bounds and cumulative segment lengths (set once at load time)
   - `Edge.CumSegLen []float64` - cumulative spherical segment distances, so `CalcProjection` no longer triple-scans the polyline (was: `Polyline.Project` + partial-sum loop + `Polyline.Length()` => now: `Polyline.Project` + O(1) lookup)
   - `Edge.BoundCenter` + `Edge.BoundRadius` - spherical cap bound from `Polyline.CapBound()`
   - new `CalcProjectionCached(edge, point)` uses the cached arrays; `CalcProjection(line, point)` still exists as a fallback (euclidean tests, hand-built edges without precomp)

4. FindNearest / SearchInRadius bbox prune
   - before the O(NumEdges) per-segment scan, check `chord(pt, edge.BoundCenter).Angle() - edge.BoundRadius` against the current worst top-N distance (or the search radius)
   - if the polyline's cap lower-bounds the distance above the threshold, skip the whole scan
   - main structural win on long motorway polylines (50+ segments)

5. Zero-copy polyline sharing in results
   - `EdgeResult.Geom` was a deep copy of `*edge.Polyline`; now it's just `*edge.Polyline` (engine's polyline is immutable after load)
   - same change in both `prepareSubMatch` and `map_matcher_simple_sp.go`
   - contract: callers must treat `Geom` as read-only

6. Loop-invariant code motion in emission/transition
   - `computeEmissionLogProbabilities`: `log(1/(sigma*sqrt(2π)))` and `1/sigma` hoisted out of the inner loop (were recomputed K times per layer via `LogNormalDistribution`)
   - `HmmProbabilities`: precomputed `invBeta` and `logInvBeta` fields, so `TransitionLogProbability` is now `logInvBeta - x*invBeta` instead of `math.Log(1/beta) - x/beta` on every call

7. Pre-allocate emission/transition slices
   - `EmissionLogProbabilities` is sized to `len(layer.States)`, `TransitionLogProbabilities` to `K*K` - no `append` growth reallocs

8. `statesIndx` map lives only in debug mode
   - was being populated unconditionally, only used inside `if ViterbiDebug` blocks for `fmt.Printf`
   - now `var statesIndx map[int]int` and only allocated inside the debug branch; release runs skip the map entirely

9. `isBreakPoint` helper fused into the build loop
   - was: build `chRoutes[i-1][*][*]`, then rescan with `isBreakPoint(prevStates, currentStates, chRoutes)` via map lookups => returns bool
   - now: `anyValidRoute bool` flag set inside the existing M×N loop whenever a non-empty path is written; `if !anyValidRoute { split segment }`
   - semantics preserved 1-to-1 for all four branches (same-edge trivial, CH jump, forward same-edge, CH vertex-to-vertex)

10. Misc small stuff the review flagged
    - index-based BFS queue in a couple of places (no interface boxing)
    - `math.Pow(x, 2)` => `x*x`
    - `sort.Slice` => `sort.Sort` with typed interface where the callback was hot
    - `resolveRoute` extracted (was inlined twice with subtle differences)

Here is pprof analysis (alloc_space, BenchmarkMapMatcherSRID_4326BIG, memprofilerate=1). This measures the edge storage win specifically - the other optimizations show up in the benchstat numbers below.

1) Total allocation

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Total alloc_space | 882.51 MB | 547.64 MB | -38% |

2) Edge storage allocations (flat, our code only)

| Source | master | EdgeGraph | Comment |
|--------|--------|-----------|---------|
| `edges[src] = make(map[int64]*Edge)` (map_engine.go:227) | 4.09 MB | - | 40k inner map headers eliminated |
| `edges[src][dst] = &edge` (map_engine.go:244) | 5.50 MB | - | inner map bucket growth eliminated |
| `EdgeGraph.Set` - lookup map (edge_graph.go:32) | - | 5.76 MB | single flat map growth |
| `EdgeGraph.Set` - adj append (edge_graph.go:42) | - | 3.33 MB | adjacency slices |
| Subtotal | 9.59 MB | 9.09 MB | -0.5 MB |

The flat storage itself is roughly break-even in bytes. The structural win is (it has been already stated above, but anyways):
- 1 hash lookup per edge access vs 2 (hot path: map matching candidates, route distance)
- slice iteration over neighbors vs map iteration (SCC, WCC on startup)
- 40k fewer heap objects - this is basically less GC scan work, especially on large graphs

Benchmark results - `BenchmarkMapMatcherSRID_4326BIG` (big graph, SRID 4326, 10 GPS points, candidates grid = 512–4096), `count=5`, `benchstat` p-values all `p=0.008`. Only the geomean row is shown; per-size results are in the same ballpark, -6% to -23% across the sweep, all statistically significant.

| Metric | master | refactor/flatMaps | Delta |
|--------|--------|-------------------|-------|
| sec/op (geomean) | 6.501 ms | 5.774 ms | -11.18% |
| B/op (geomean)   | 2.684 MiB | 2.381 MiB | -11.27% |
| allocs/op (geomean) | 26.22k | 24.40k | -6.94% |

On the original `BenchmarkMapMatcherSRID_4326` (small graph) and the routing/isochrones benchmarks the difference is smaller - the small graph just doesn't exercise the nested-map / polyline-scan pressure enough. The benefit scales with graph size and polyline density.

You can ask: "why not CSR (Compressed Sparse Row)"?

CSR would give the best cache locality but requires:
- vertex ID as for index mapping (IDs are sparse int64, not 0..N)
- immutable after construction (no dynamic insert)
- significantly more code complexity I think

The hybrid approach (flat lookup map + adjacency slices) gives 90% of the benefit with minimal code struggles and all call sites are mechanical replacements (I hope so).

Notes on behaviour / contracts:
- `EdgeResult.Geom` is now a shared view into the engine's polyline. Callers must treat it as read-only. If a caller needs to mutate (unlikely in current code), they must copy.
- `Edge.CumSegLen` and `Edge.BoundCenter/BoundRadius` are populated once in `map_engine.go` after edge construction. Edges built by hand in tests without calling `PrecomputeCumLen` / `PrecomputeBound` will fall back to the slow path (`CalcProjectionCached` falls through to `CalcProjection`; `FindNearest` skips bbox prune when `BoundRadius == 0`).
- Test edge-comparison: `spatial.Edge` now contains `[]float64` (`CumSegLen`), which makes the struct non-comparable via `==`/`!=`. The one test that compared edges this way (`map_matcher_4326_small_test.go`) was updated to compare by `(Source, Target, ID)` - the triplet that actually identifies an edge in the graph.

Misc:
- Bumped [viterbi](https://github.com/LdDl/viterbi/releases/tag/v1.2.0) to v1.2.0

I am doing this work for my scientific curiosity (actually part of my job in the University I work for), so I don't have a specific timeline or deadline. I will keep iterating on this PR until I am satisfied with the results.